### PR TITLE
chore(flake/fenix): `bd91b6fd` -> `035306bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1643610217,
-        "narHash": "sha256-3cFZt9Eyz70s1CNYO3wJeUDgLUC9tC4s5hNpLtX3FQY=",
+        "lastModified": 1644301403,
+        "narHash": "sha256-taOPTgB1EFlj7oyG40mplff45QYMJeQ0/Pm4lLuBZ+A=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "bd91b6fddf7fdf90ad9924339fcb40f008f57447",
+        "rev": "035306bc8de70b8ed7d79f1fd15d3e2b32ef1dde",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1643580505,
-        "narHash": "sha256-6+d/x7ZIyvkPLdn7ziXuPyKfxt/7z5PCWs7B960DFqk=",
+        "lastModified": 1644220273,
+        "narHash": "sha256-6zg648bgcZkcEeLjTXo+ESCR8DVgF9V4Hw7zjiv8OBY=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "fd3942eb620e37a4e4bfdd587d8a2893ccf6fea0",
+        "rev": "9b1978a3ed405c2a5ec34703914ec1878b599e14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`035306bc`](https://github.com/nix-community/fenix/commit/035306bc8de70b8ed7d79f1fd15d3e2b32ef1dde) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d45b0624`](https://github.com/nix-community/fenix/commit/d45b0624e9f66f656fd2bbdb3cdbb205bfbbc110) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`cd2ef666`](https://github.com/nix-community/fenix/commit/cd2ef666d624b0bbf6d9bb4e5bac8c33d3c6d95a) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`22d75c5e`](https://github.com/nix-community/fenix/commit/22d75c5e603572a1acb840f9b6d3dd87c1c5c1ea) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b6b464e0`](https://github.com/nix-community/fenix/commit/b6b464e07377d9cb21832191292ef971cf11c208) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2d64d0c1`](https://github.com/nix-community/fenix/commit/2d64d0c1941b2b82d938e82790ea0e692889c23b) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`bc649b42`](https://github.com/nix-community/fenix/commit/bc649b429aa1fabce3ec7ca476ef377c86647797) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`06e7c3fc`](https://github.com/nix-community/fenix/commit/06e7c3fc9cdb2f6a3bfd2886b0a2c3aedf3529c7) | `update: rust toolchains, rust analyzer, flake.lock` |