### PR TITLE
chore(flake/fenix): `035306bc` -> `f078968e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1644301403,
-        "narHash": "sha256-taOPTgB1EFlj7oyG40mplff45QYMJeQ0/Pm4lLuBZ+A=",
+        "lastModified": 1645943033,
+        "narHash": "sha256-es7SEXoeWqv0blb8s+AVWOUygsRDIcx7G/8FIUUEjZE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "035306bc8de70b8ed7d79f1fd15d3e2b32ef1dde",
+        "rev": "f078968e47b20286d9f6b11c528cb0e5d73aa1fb",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1644220273,
-        "narHash": "sha256-6zg648bgcZkcEeLjTXo+ESCR8DVgF9V4Hw7zjiv8OBY=",
+        "lastModified": 1645823844,
+        "narHash": "sha256-zCrxupBXHKm9pakFTcxng/PMbAmiRRK58ZewtBfwc50=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "9b1978a3ed405c2a5ec34703914ec1878b599e14",
+        "rev": "a2cc1d6b7b499d6b03436db7fc8053aea72f75ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`f078968e`](https://github.com/nix-community/fenix/commit/f078968e47b20286d9f6b11c528cb0e5d73aa1fb) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`dcb7ebe9`](https://github.com/nix-community/fenix/commit/dcb7ebe94999dc84da08b6b8fd88d86030b71302) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`89ac7f1e`](https://github.com/nix-community/fenix/commit/89ac7f1e75cd2edd38cb5a876e6587b79f01c17a) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`a372f826`](https://github.com/nix-community/fenix/commit/a372f826fbc2148fe6fac619c2ff93fd89e9896b) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`6c8d60c1`](https://github.com/nix-community/fenix/commit/6c8d60c1d8deba8c360537c47e2b86aefaea0fd5) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`972ccdaa`](https://github.com/nix-community/fenix/commit/972ccdaa28b811150391e21397f4bf93ded601cd) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`882a8123`](https://github.com/nix-community/fenix/commit/882a812300adcd85a5e10dc26e5d7a1d6acc7575) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`f15f0f9f`](https://github.com/nix-community/fenix/commit/f15f0f9fedd87e265e49585463df72c1257f1ae8) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`9892337b`](https://github.com/nix-community/fenix/commit/9892337b588c38ec59466a1c89befce464aae7f8) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`380b82e3`](https://github.com/nix-community/fenix/commit/380b82e3d3381b32f11dfe024cb7d135e36d0168) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`1a1694cb`](https://github.com/nix-community/fenix/commit/1a1694cb7ae3708a90932e7a8a9a767c466a2976) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8fa7c3c9`](https://github.com/nix-community/fenix/commit/8fa7c3c91809cd9665a2391890469160c5ba01dd) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d3c8588f`](https://github.com/nix-community/fenix/commit/d3c8588f3a921dbc676ec22fc257ff126deacf54) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`283666b7`](https://github.com/nix-community/fenix/commit/283666b7c54f0da4c9514baa85f472dcd4b8fdff) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`9752af7c`](https://github.com/nix-community/fenix/commit/9752af7c4f9b143a8e687dcac54629d61763454a) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`00125e22`](https://github.com/nix-community/fenix/commit/00125e22196257fc52b690fc9c1ec5f0d11703ff) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`6fbfc282`](https://github.com/nix-community/fenix/commit/6fbfc2821a058eb820bb3742a762bbba5a99f0df) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2ac45eb4`](https://github.com/nix-community/fenix/commit/2ac45eb4b067715f53a94769d6a0882a19eb93d3) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`f950cc50`](https://github.com/nix-community/fenix/commit/f950cc5036dc2a6631d39e0887e9f6a9a92c4dd9) | `update: rust toolchains, rust analyzer, flake.lock` |