### PR TITLE
chore(flake/fenix): `f078968e` -> `985a64f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1645943033,
-        "narHash": "sha256-es7SEXoeWqv0blb8s+AVWOUygsRDIcx7G/8FIUUEjZE=",
+        "lastModified": 1648707977,
+        "narHash": "sha256-b8d0KyogxhyBEGFwPIG8lub/5YxkFybN4Htl/h2Ihqg=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f078968e47b20286d9f6b11c528cb0e5d73aa1fb",
+        "rev": "985a64f6ac2c1f36d7cd7076096f9fdbf1eae0b7",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1645823844,
-        "narHash": "sha256-zCrxupBXHKm9pakFTcxng/PMbAmiRRK58ZewtBfwc50=",
+        "lastModified": 1648648130,
+        "narHash": "sha256-i7PNH20SGr0w3tP4ipIRhaK21IYo66y1YdYW+5HcJ/8=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "a2cc1d6b7b499d6b03436db7fc8053aea72f75ac",
+        "rev": "259182b50b131647975926e8c94aad4c47d33747",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`985a64f6`](https://github.com/nix-community/fenix/commit/985a64f6ac2c1f36d7cd7076096f9fdbf1eae0b7) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`79e7fb83`](https://github.com/nix-community/fenix/commit/79e7fb83486d1d1f2240d4e42bd581506422825c) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b453394e`](https://github.com/nix-community/fenix/commit/b453394e9037bdc5c9780b2158ab66d81020ae96) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`1404ff30`](https://github.com/nix-community/fenix/commit/1404ff303fd01cfbc8219fb5f9ca4159d16881e2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fa5daaaa`](https://github.com/nix-community/fenix/commit/fa5daaaa15118b4721beb0983e8a1d56a4ddb0f5) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`7a6178fd`](https://github.com/nix-community/fenix/commit/7a6178fd9e9f8c1df931740bb5ca33acfcc01b7d) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`9982a25f`](https://github.com/nix-community/fenix/commit/9982a25f9538e4aabb15b50e79a14f84135c4e14) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`c16c2ff9`](https://github.com/nix-community/fenix/commit/c16c2ff9fd7709acd8583c2b87889c100795ae5c) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`dc8cab14`](https://github.com/nix-community/fenix/commit/dc8cab143c1ea4ed9e105723ae9ef3dd76d6177e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d42fa946`](https://github.com/nix-community/fenix/commit/d42fa946dd0cdf3db6131a781d9f5f58a1e41818) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`f7e1b7cd`](https://github.com/nix-community/fenix/commit/f7e1b7cd801a00847571d3a5cdb5b5c7063b9b83) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`711a9c51`](https://github.com/nix-community/fenix/commit/711a9c519cef08f05ed6487285f17fae214ae50d) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8881b72b`](https://github.com/nix-community/fenix/commit/8881b72bbf95655ff2a41b8daea599a8b3dd6c92) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`40ef7c65`](https://github.com/nix-community/fenix/commit/40ef7c65243fa9894e8d6ea87b8e85d117062f9d) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fde106f4`](https://github.com/nix-community/fenix/commit/fde106f4de112e571d3d1f56314629ad0ff425ac) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`a7f5fe12`](https://github.com/nix-community/fenix/commit/a7f5fe126561d68d0490ca41a936501fb940e05e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`0c97deed`](https://github.com/nix-community/fenix/commit/0c97deed53f3fd853a53420dbf489e42ba8160e1) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8c789f87`](https://github.com/nix-community/fenix/commit/8c789f87420da66ebb6214892d5c0c013b0b2486) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`822fa847`](https://github.com/nix-community/fenix/commit/822fa8472eecbf8f45e342a246caeda36be4e7e5) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`5a8330a6`](https://github.com/nix-community/fenix/commit/5a8330a6112141ff94ed5bf2fbe88e5cf57ab5a9) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`db9cb6e2`](https://github.com/nix-community/fenix/commit/db9cb6e26b67195549e5c2c1515a9f5c88d2b7e5) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`aad7f0a3`](https://github.com/nix-community/fenix/commit/aad7f0a3e44ecfc9e2c5f1a45387d193c1c51aa6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`3ec0bd86`](https://github.com/nix-community/fenix/commit/3ec0bd869a372e0e43dd469021313712fb1b9129) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`15ccda75`](https://github.com/nix-community/fenix/commit/15ccda7515234a84298d38c42496c84a4fe29804) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`6fdda0fa`](https://github.com/nix-community/fenix/commit/6fdda0faec538afde79431357ccc87d85c8783f4) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`0f3501f9`](https://github.com/nix-community/fenix/commit/0f3501f9d2be7f9ed272be4822bc91581137f325) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`aeac7629`](https://github.com/nix-community/fenix/commit/aeac7629f1d069e6f874cd044453a7ed1c2cefd7) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`afda898f`](https://github.com/nix-community/fenix/commit/afda898f6ab947e013cfb43f9ae65c9fa4ed786f) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`df8c8cd9`](https://github.com/nix-community/fenix/commit/df8c8cd9154589ef8693c912dd6bfb59c1b90c69) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`f07a7f5c`](https://github.com/nix-community/fenix/commit/f07a7f5c0c97cbfead53b84a96127bfa1e6363d2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8e4188d7`](https://github.com/nix-community/fenix/commit/8e4188d751801d14e670ee55475f943a7c2a18d2) | `build(deps): bump actions/checkout from 2.4.0 to 3` |
| [`637a0fde`](https://github.com/nix-community/fenix/commit/637a0fde617a93d01e5275946402cca15d50ef46) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`275fce9b`](https://github.com/nix-community/fenix/commit/275fce9bf849440de526df1e421a67b5d3b6a1c0) | `update: rust toolchains, rust analyzer, flake.lock` |