### PR TITLE
chore(flake/flake-utils): `3cecb5b0` -> `0f8662f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0f8662f1`](https://github.com/numtide/flake-utils/commit/0f8662f1319ad6abf89b3380dd2722369fc51ade) | `Bugfix: simpleFlake works only on x86 and Linux (#57)` |