### PR TITLE
chore(flake/naersk): `2fc8ce9d` -> `e30ef9a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "lastModified": 1648544490,
+        "narHash": "sha256-EoBDcccV70tfz2LAs5lK0BjC7en5mzUVlgLsd5E6DW4=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "rev": "e30ef9a5ce9b3de8bb438f15829c50f9525ca730",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e30ef9a5`](https://github.com/nix-community/naersk/commit/e30ef9a5ce9b3de8bb438f15829c50f9525ca730) | ``readme: Remove invalid link for `Comparison``` |