### PR TITLE
chore(flake/nixpkgs): `21968db3` -> `10632447`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646051047,
-        "narHash": "sha256-XDJGACWVeNs3OAECpx20zegX/YDigHOUZ1nVmCJUeEM=",
+        "lastModified": 1648673296,
+        "narHash": "sha256-dlQP4/escrnt8vm1WAbWrYeFvYF1F1K3m+9qsUHwL+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21968db378c9144f418c1e8e7002316aa8b75776",
+        "rev": "1063244793d9b2dc3db515ac5b70a85385ec9b10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`0a2ae8bc`](https://github.com/NixOS/nixpkgs/commit/0a2ae8bc533dc4320f8460949ec154398800fb09) | `gh: 2.6.0 -> 2.7.0`                                                     |
| [`90c46e80`](https://github.com/NixOS/nixpkgs/commit/90c46e80c66d1616882ea472d536e5c3f8a7857a) | `python310Packages.huawei-lte-api: 1.5.4 -> 1.6`                         |
| [`b2635c2b`](https://github.com/NixOS/nixpkgs/commit/b2635c2b71150ec1ab0e3a591685f653b5db7485) | `python3Packages.tensorflow-datasets: run tests in parallel`             |
| [`45709072`](https://github.com/NixOS/nixpkgs/commit/4570907282908a9f423807750994212abd803412) | `python3Packages.optax: run tests in parallel`                           |
| [`6fa30f68`](https://github.com/NixOS/nixpkgs/commit/6fa30f68552aa526a13382f2f0120736660219d2) | `python3Packages.flax: run tests in parallel`                            |
| [`740a83a9`](https://github.com/NixOS/nixpkgs/commit/740a83a9bdb25fdf0ca3bdcc187f329d1969ee07) | `python3Packages.dm-haiku: run tests in parallel`                        |
| [`3c25104d`](https://github.com/NixOS/nixpkgs/commit/3c25104d0e88e949d30ce67a1b693ab59ec9155d) | `stripe-cli: add meta.mainProgram (#166457)`                             |
| [`a01a4d4d`](https://github.com/NixOS/nixpkgs/commit/a01a4d4d678e0075440bae47e7c323403027f896) | `wp-cli: add meta.mainProgram (#166453)`                                 |
| [`6aa45d8b`](https://github.com/NixOS/nixpkgs/commit/6aa45d8b5943eb03269a67d1a7646d8010fb7996) | `wl-mirror: 0.8.1 -> 0.9.2`                                              |
| [`95b8f0a8`](https://github.com/NixOS/nixpkgs/commit/95b8f0a84ad7329fda0a05201252888ec94cda80) | `python310Packages.libcloud: 3.5.0 -> 3.5.1`                             |
| [`e01c4120`](https://github.com/NixOS/nixpkgs/commit/e01c41205234a68a55903e05800e62d0de302e1a) | `fuzzel: fixup build after librsvg update`                               |
| [`b0d30448`](https://github.com/NixOS/nixpkgs/commit/b0d3044823591c4947a82cd43f0d3e17b3abece4) | `haskellPackages.graphql: convert assert on hspec into warning`          |
| [`13c34c9a`](https://github.com/NixOS/nixpkgs/commit/13c34c9a86981fc7cca93475b7017d8e9acafa89) | `profanity: 0.11.1 -> 0.12.0`                                            |
| [`bb22a2de`](https://github.com/NixOS/nixpkgs/commit/bb22a2debcbb2695a4eb1be9b319952f17cfefb2) | `nixos/zrepl: note about systemd unit, add snapshot test`                |
| [`288c8f8f`](https://github.com/NixOS/nixpkgs/commit/288c8f8fbe3453f1bb5fb717a26f94ac50754067) | `oil: 0.9.8 -> 0.9.9`                                                    |
| [`0a380794`](https://github.com/NixOS/nixpkgs/commit/0a3807942595869cf21027e0fa799368e3ac7442) | `ntfy-sh: init at 1.18.1 (#166102)`                                      |
| [`2337e48a`](https://github.com/NixOS/nixpkgs/commit/2337e48adb6dc88bdb2dceb433770180c28bf288) | `oh-my-zsh: 2022-03-28 -> 2022-03-29 (#166373)`                          |
| [`c84d82e9`](https://github.com/NixOS/nixpkgs/commit/c84d82e9627f3d681be67b140a0b646deb9f18fb) | `bullet: 3.21 -> 3.22a`                                                  |
| [`43b5a5ec`](https://github.com/NixOS/nixpkgs/commit/43b5a5ec59098dc94ff32eb2a8b5e43fe9cab6a9) | `postman: add darwin packages (#164697)`                                 |
| [`b9b68043`](https://github.com/NixOS/nixpkgs/commit/b9b680439852b9f4511d672fd56c349bd80b95c5) | `python310Packages.pylitterbot: 2021.12.0 -> 2022.3.0`                   |
| [`2344c427`](https://github.com/NixOS/nixpkgs/commit/2344c427cfbecf3da911a923fa1c8a8016a5dd07) | `nfpm: 2.15.0 -> 2.15.1`                                                 |
| [`07d588de`](https://github.com/NixOS/nixpkgs/commit/07d588de4db68e8094b16fe100eb15fef72b417a) | `morgen: 2.4.4 -> 2.5.0`                                                 |
| [`ef7564a0`](https://github.com/NixOS/nixpkgs/commit/ef7564a0acae0118b882a80df6e9cb35beaaee7f) | `python3Packages.metar: disable test, remove patch`                      |
| [`cec30d58`](https://github.com/NixOS/nixpkgs/commit/cec30d5845d0aa7a80c1740ce6dfb11c47d7b57e) | `python310Packages.desktop-notifier: 3.3.5 -> 3.4.0`                     |
| [`a8dfd8fd`](https://github.com/NixOS/nixpkgs/commit/a8dfd8fdac5eef9bd5dd04bdd343de2331231c27) | `entangle: fix build with meson 0.61`                                    |
| [`d23a53bd`](https://github.com/NixOS/nixpkgs/commit/d23a53bd363216299f1c2ea51984ca8d5fcec60a) | `drawing: fix build with meson 0.61`                                     |
| [`a1d2c351`](https://github.com/NixOS/nixpkgs/commit/a1d2c3511f5de62fcb7d848d83f7eb0024bba4b4) | `nvidia_x11: 470.94 → 470.103.01`                                        |
| [`0ec675a1`](https://github.com/NixOS/nixpkgs/commit/0ec675a11dc6c770b74c472269404b3a0392013b) | `python310Packages.geojson-client: 0.7 -> 0.8`                           |
| [`dd697d41`](https://github.com/NixOS/nixpkgs/commit/dd697d414853a99d0d5f05ee23430923c6da1176) | `strawberry: add libgpod`                                                |
| [`4ceda585`](https://github.com/NixOS/nixpkgs/commit/4ceda5853fa4530ec989e902081d51c6e7159328) | `drop shards_0_15`                                                       |
| [`37463c21`](https://github.com/NixOS/nixpkgs/commit/37463c21cc9270a2c35e2681295f9fe5368596c7) | `shards: 0.16 -> 0.17`                                                   |
| [`8cc2efce`](https://github.com/NixOS/nixpkgs/commit/8cc2efce4a5c01d5efaf86767ee6a33a985cf5ae) | `python3Packages.msldap: disable on older Python releases`               |
| [`645796c0`](https://github.com/NixOS/nixpkgs/commit/645796c0cb544431c0ee3bfad48f12bf9867bd78) | `dconf-editor: fix build with Meson 0.61`                                |
| [`289a54ef`](https://github.com/NixOS/nixpkgs/commit/289a54ef8dc95e90ba20bb73751c5291d1aee881) | `dconf-editor: Respect NIX_GSETTINGS_OVERRIDES_DIR variable`             |
| [`5fa8d3ac`](https://github.com/NixOS/nixpkgs/commit/5fa8d3ac3871ca58b56dcc9a4de2b246053ca27e) | `gnome-2048: fix build with meson 0.61`                                  |
| [`68824fbc`](https://github.com/NixOS/nixpkgs/commit/68824fbc89d6105cf2bf997bae51bc281d8bad52) | `gnome.gnome-screenshot: fix build with meson 0.61`                      |
| [`dbc55b66`](https://github.com/NixOS/nixpkgs/commit/dbc55b66671e4bb4479b37dbd484118985048a9e) | `gnome.gnome-screenshot: format`                                         |
| [`3d1d33c5`](https://github.com/NixOS/nixpkgs/commit/3d1d33c5ff17c582cea2f0f63a65cb37cc43318c) | `gnome.gnome-books: fix build with meson 0.61`                           |
| [`d3dab0e6`](https://github.com/NixOS/nixpkgs/commit/d3dab0e67dcceacc7b09d1c65f7442c6ee7ba656) | `gnome.devhelp: fix build with meson 0.61`                               |
| [`feb68f31`](https://github.com/NixOS/nixpkgs/commit/feb68f31e12b85dbf55bb4df3e60adba6b86475b) | `python310Packages.msldap: 0.3.30 -> 0.3.38`                             |
| [`a7cfb52b`](https://github.com/NixOS/nixpkgs/commit/a7cfb52b0a08282a655c32c8b93c3dbf0c9830e0) | `python310Packages.asyncmy: 0.2.4 -> 0.2.5`                              |
| [`9f4b404b`](https://github.com/NixOS/nixpkgs/commit/9f4b404b5cb159b6630485326e8dcebabad222f5) | `maintainers/teams: add cosmopolitan team`                               |
| [`bd84351d`](https://github.com/NixOS/nixpkgs/commit/bd84351def15c0fe7a8a387347a6f10b4805f6ca) | `python-cosmopolitan: init at 3.6.14`                                    |
| [`f760f24d`](https://github.com/NixOS/nixpkgs/commit/f760f24de31ba7f01d3eecc017b499e738eefaec) | `doc/release-notes: document cosmoc removal`                             |
| [`d1eb392e`](https://github.com/NixOS/nixpkgs/commit/d1eb392e95c2ec286162bd567c5e15d8fdc1a855) | `cosmopolitan: remove redundant fix`                                     |
| [`96d31267`](https://github.com/NixOS/nixpkgs/commit/96d31267813b8ed32e480ad7c9bbc9a7e4e9a86c) | `cosmopolitan: lint`                                                     |
| [`89604525`](https://github.com/NixOS/nixpkgs/commit/89604525d7aafa64f66769d7d05990dc5b31a56a) | `cosmopolitan: unclutter output`                                         |
| [`f92cfbce`](https://github.com/NixOS/nixpkgs/commit/f92cfbce3aab64699bbb73199611ab6144c71cf4) | `cosmopolitan: remove redundant test`                                    |
| [`0d5810ed`](https://github.com/NixOS/nixpkgs/commit/0d5810ede00b98e6e0cf01bc9e5da8fea4611201) | `cosmoc: init`                                                           |
| [`ff4d8134`](https://github.com/NixOS/nixpkgs/commit/ff4d8134a2ece2f6f4fe9ca0dc1d12dcbf453f6f) | `sane-backend: deprecate phases`                                         |
| [`7e845eda`](https://github.com/NixOS/nixpkgs/commit/7e845eda916d48ecd05978bdef1218c5d1195c28) | `spike: 1.0.0 -> 1.1.0`                                                  |
| [`b92c00e5`](https://github.com/NixOS/nixpkgs/commit/b92c00e5ef21a8d58e028a7637592af1f40c3e12) | `python310Packages.dash: 2.3.0 -> 2.3.1`                                 |
| [`1121300b`](https://github.com/NixOS/nixpkgs/commit/1121300b4195a540d66c012280a52545d99ae430) | `lief: 0.11.5 -> 0.12.0`                                                 |
| [`ebeae143`](https://github.com/NixOS/nixpkgs/commit/ebeae1436ff4136411f3c9216c7e873be4c5c1dc) | `janet: 1.21.0 -> 1.21.1`                                                |
| [`eedeae90`](https://github.com/NixOS/nixpkgs/commit/eedeae90ae52551706b44532ed3053391166cf7c) | `python310Packages.stripe: 2.68.0 -> 2.69.0`                             |
| [`88a70a93`](https://github.com/NixOS/nixpkgs/commit/88a70a935ecbae6c5a9546200790c1188674c099) | `mycli: 1.24.3 -> 1.24.4`                                                |
| [`c9e8b42e`](https://github.com/NixOS/nixpkgs/commit/c9e8b42ecae56c88f5b12ad8c8e95e588278eff6) | `2048-in-terminal: expand platforms to unix`                             |
| [`71317b98`](https://github.com/NixOS/nixpkgs/commit/71317b9801ea3545c704652ecff1b904842c2066) | `python310Packages.pyoverkiz: 1.3.12 -> 1.3.13`                          |
| [`d78f645e`](https://github.com/NixOS/nixpkgs/commit/d78f645ea120eb1c2cca3a14b36a9601a186f664) | `cudatoolkit_11: cudatoolkit_11_6 → cudatoolkit_11_5`                    |
| [`6d2ac25d`](https://github.com/NixOS/nixpkgs/commit/6d2ac25d30444a59adfbb520dc544b0c67f5604d) | `python310Packages.hahomematic: 1.0.0 -> 1.0.3`                          |
| [`57a54d6e`](https://github.com/NixOS/nixpkgs/commit/57a54d6e57a0e6cd460e0a44ff784c4287df69f3) | `evil-winrm: init at 3.3 (#153752)`                                      |
| [`b376c1ce`](https://github.com/NixOS/nixpkgs/commit/b376c1ce9df5ac104baff7d0ce5048d16c485348) | `linuxPackages.nvidia_x11_legacy390: mark as broken`                     |
| [`40ded161`](https://github.com/NixOS/nixpkgs/commit/40ded1611de3dc1d672613e90b2f8c1d1ed145f2) | `dvc: 2.9.3 -> 2.9.5`                                                    |
| [`f687794f`](https://github.com/NixOS/nixpkgs/commit/f687794fb59d51167cdb88826f28966c4b722d1e) | `python39Packages.snowflake-connector-python: 2.7.4 -> 2.7.6`            |
| [`a677b22a`](https://github.com/NixOS/nixpkgs/commit/a677b22ac044292daa73ad56deab6e15af8a451e) | `esphome: 2022.3.1 -> 2022.3.2`                                          |
| [`889fd0ca`](https://github.com/NixOS/nixpkgs/commit/889fd0ca40b06cc040b3640a70de8a3c977587f9) | `_1password: fixup packaging`                                            |
| [`5a0fc971`](https://github.com/NixOS/nixpkgs/commit/5a0fc971ad3175cc4aafeecc9bcfb1c2a4bdb5fb) | `python39Packages.paramiko: add comment about pytest-relaxed`            |
| [`8b3e54b4`](https://github.com/NixOS/nixpkgs/commit/8b3e54b48545d02a3b21581c4a5fb96a0261a79e) | `onefetch: 2.11.0 -> 2.12.0`                                             |
| [`befae9fc`](https://github.com/NixOS/nixpkgs/commit/befae9fcbdcbf2c095e457739744e4149b79f860) | `vimPlugins.urlview-nvim: init at 2022-03-29`                            |
| [`71f7aca0`](https://github.com/NixOS/nixpkgs/commit/71f7aca0c236eb29781aaa099d731167eb4d2966) | `vimPlugins.pywal-nvim: init at 2022-02-20`                              |
| [`5e3265af`](https://github.com/NixOS/nixpkgs/commit/5e3265af04cc467ad6f2e57c812610ab0483a9c7) | `pulumi: 3.26.1 -> 3.27.0`                                               |
| [`44f80c6c`](https://github.com/NixOS/nixpkgs/commit/44f80c6cbf3da72de5eac77c88f65c2fa72af625) | `python3Packages.jinja2: update homepage`                                |
| [`b9c5ad1c`](https://github.com/NixOS/nixpkgs/commit/b9c5ad1c06328e058ca80bc2cb9884f37cbef564) | `gnomeExtensions: auto-update`                                           |
| [`32a8f307`](https://github.com/NixOS/nixpkgs/commit/32a8f307ac13271f8a362a7db8349733e76a1c75) | `aesfix: init at v1.0.1`                                                 |
| [`1c0f4cb8`](https://github.com/NixOS/nixpkgs/commit/1c0f4cb80963872a9133482fa1c7d2c4e2e719e7) | `fuse: fix nix-update/nix-prefetch crashing`                             |
| [`8d636482`](https://github.com/NixOS/nixpkgs/commit/8d636482f1eb7113e629ae604074e4c706068c1f) | `jetbrains.clion: fix build`                                             |
| [`630732fd`](https://github.com/NixOS/nixpkgs/commit/630732fdd76df34ea988eaeb7b552992de737971) | `.github/CODEOWNERS: remove non-committer users/teams`                   |
| [`00f86956`](https://github.com/NixOS/nixpkgs/commit/00f86956582eb673ad853e245f0e824ad1fe2897) | `actionlint: wrap with shellcheck and pyflakes`                          |
| [`9fd8faf8`](https://github.com/NixOS/nixpkgs/commit/9fd8faf82457445ee3cb86250611551f9ce2a171) | `python39Packages.ansible-lint: 5.3.2 -> 6.0.2`                          |
| [`bada6a2e`](https://github.com/NixOS/nixpkgs/commit/bada6a2e04b5801a0ac8487a4bd189b51726f733) | `nixos/nix-daemon: fix typo`                                             |
| [`b2ff4f21`](https://github.com/NixOS/nixpkgs/commit/b2ff4f21bec1e2138477865b5c4f89d95e2e8448) | `python39Packages.pytest-relaxed: mark broken`                           |
| [`4b9e65e0`](https://github.com/NixOS/nixpkgs/commit/4b9e65e0664703ce7e0fbb9d256265e799d22f7c) | `chromiumBeta: 100.0.4896.56 -> 100.0.4896.60`                           |
| [`b647d5a4`](https://github.com/NixOS/nixpkgs/commit/b647d5a49d0ac80512f3169789042ac124e23f2c) | `chromium: 99.0.4844.84 -> 100.0.4896.60`                                |
| [`2682154e`](https://github.com/NixOS/nixpkgs/commit/2682154e8928dd32ebe07789aa3a5a9dcabb2bce) | `gnomeExtensions.sound-output-device-chooser: 39 -> unstable-2022-03-29` |
| [`03801d38`](https://github.com/NixOS/nixpkgs/commit/03801d38119cdcd299c442b5f054a0c3421fe782) | `sile: 0.12.3 → 0.12.4`                                                  |
| [`ab704e8a`](https://github.com/NixOS/nixpkgs/commit/ab704e8a27fcf59dc9b5e9cc9962000c678235a2) | `sile: 0.12.2 → 0.12.3`                                                  |
| [`b5dbfba1`](https://github.com/NixOS/nixpkgs/commit/b5dbfba122c06646993833443aecb92135991789) | `cypress: 9.5.2 -> 9.5.3`                                                |
| [`b77b6bca`](https://github.com/NixOS/nixpkgs/commit/b77b6bca3848113a1cd85ed9d04a7f232d088aaf) | `roon-bridge: 1.8-880 -> 1.8-918`                                        |
| [`fed59bde`](https://github.com/NixOS/nixpkgs/commit/fed59bdef375bbf21442b82fe378881cba0bf650) | `roon-server: 1.8-903 -> 1.8-923`                                        |
| [`452508d9`](https://github.com/NixOS/nixpkgs/commit/452508d96b3979224cb4282b25882478a52a4da4) | `arkade: 0.8.14 -> 0.8.16`                                               |
| [`9f16d661`](https://github.com/NixOS/nixpkgs/commit/9f16d661c8a601c5a81b2d033a675ff764176348) | `tflint: 0.34.1 -> 0.35.0`                                               |
| [`e5bf0233`](https://github.com/NixOS/nixpkgs/commit/e5bf0233a8889b4dfd3490a854cf9caba216a943) | `f1viewer: 2.6.0 -> 2.6.2`                                               |
| [`cb479c5a`](https://github.com/NixOS/nixpkgs/commit/cb479c5a92d2234668a2d9cdf67011df161ac61b) | `esbuild: 0.14.27 -> 0.14.28`                                            |
| [`4d5c0f0b`](https://github.com/NixOS/nixpkgs/commit/4d5c0f0ba4fabbfd447c62ed1eb2d06cff7e83de) | `python39Packages.pycrypto: update meta`                                 |
| [`3057fe56`](https://github.com/NixOS/nixpkgs/commit/3057fe56ebac9adc98a82bacf6c07840c831ce41) | `python310Packages.ansible-compat: init at 0.5.0`                        |
| [`0d2fc67c`](https://github.com/NixOS/nixpkgs/commit/0d2fc67c5011d4716770c99ab673159bd703e9ca) | `python310Packages.bids-validator: 1.9.2 -> 1.9.3`                       |
| [`08ab0fab`](https://github.com/NixOS/nixpkgs/commit/08ab0fab0a7058f099b7d73dc9692419097b0336) | `python3Packages.click: add downstream tests`                            |
| [`388382de`](https://github.com/NixOS/nixpkgs/commit/388382de81a53a4331a29545b6c2db88e3b11993) | `python3Packages.azure-keyvault-keys: disable on older Python releases`  |
| [`1a718a16`](https://github.com/NixOS/nixpkgs/commit/1a718a1677940796b42486b659aa29344c956e49) | `python310Packages.azure-keyvault-keys: 4.4.0 -> 4.5.0`                  |
| [`b228be7e`](https://github.com/NixOS/nixpkgs/commit/b228be7ef6c602b1d096a8e50bd563d1f38ed9ae) | `python3Packages.osmnx: 1.1.1 → 1.1.2`                                   |
| [`8e27053f`](https://github.com/NixOS/nixpkgs/commit/8e27053ff079c2a34d50b7ca7ab8759113670ed2) | `python310Packages.azure-keyvault-administration: 4.0.0 -> 4.1.0`        |
| [`6443507c`](https://github.com/NixOS/nixpkgs/commit/6443507c122a6b17397c8efecfea23c25024dc01) | `cosmopolitan: add checkPhase`                                           |
| [`961472b7`](https://github.com/NixOS/nixpkgs/commit/961472b74a1c1873b548075973b4fa592b06ffe8) | `cosmopolitan: only build libc`                                          |
| [`1c223b63`](https://github.com/NixOS/nixpkgs/commit/1c223b63439ce7ddb5ac36138c03ba306794a9e1) | `element{-desktop,}: 1.10.7 -> 1.10.8`                                   |
| [`64ead2ba`](https://github.com/NixOS/nixpkgs/commit/64ead2ba7da2da3b269cff762c83c705e9dd6f11) | `unifi7: 7.0.23 -> 7.0.25`                                               |
| [`796056a4`](https://github.com/NixOS/nixpkgs/commit/796056a4b97228d32b506f12f4a13c073c303585) | `xkeysnail: update example config`                                       |
| [`41e26044`](https://github.com/NixOS/nixpkgs/commit/41e2604483babe9e70429887ff5293aaa8bdb1bb) | `nixos/dhcpd6: Use fixed-address6 for dhcpd6 address reservations`       |
| [`316e4a4c`](https://github.com/NixOS/nixpkgs/commit/316e4a4ca184512a1620baf014452c97bc11b025) | `perlPackages.PLS: shorten shebang on Darwin`                            |
| [`66cb2008`](https://github.com/NixOS/nixpkgs/commit/66cb200860e0e399460e9c18b8e79b05b0375fe7) | `python3Packages.notifymuch: Init at 0.1 (#166075)`                      |
| [`8d7ec2bd`](https://github.com/NixOS/nixpkgs/commit/8d7ec2bd7e95a5816f427bb1909a46e355314f9a) | `python3Packages.rasterio: 1.2.6 → 1.2.10`                               |
| [`5115f5bb`](https://github.com/NixOS/nixpkgs/commit/5115f5bb8c1c18ff8ef95b5b8fbf61b61707ab36) | `cargo-spellcheck: 0.11.0 -> 0.11.1`                                     |
| [`ea35502f`](https://github.com/NixOS/nixpkgs/commit/ea35502fe4db6f9be94ae8461bf14c223ccef180) | `xtris: fix darwin build`                                                |
| [`448c1d0e`](https://github.com/NixOS/nixpkgs/commit/448c1d0e86cc8f77b07d9a389340e3e1ffbdd3f0) | `polkadot: fix darwin build`                                             |
| [`e0e1ad16`](https://github.com/NixOS/nixpkgs/commit/e0e1ad16be1a8c0e1038961e5df2973e6927cc57) | `krelay: init at 0.0.2`                                                  |
| [`b7e6749a`](https://github.com/NixOS/nixpkgs/commit/b7e6749a32a2d9950a753138b614f7b543c96d9b) | `home-assistant: 2022.3.7 -> 2022.3.8`                                   |
| [`e9c2918e`](https://github.com/NixOS/nixpkgs/commit/e9c2918e9bce73019f9581b26555bbd5bcb44e78) | `gnome.gnome-control-center: fix Online Accounts configuration on X11`   |
| [`066634e5`](https://github.com/NixOS/nixpkgs/commit/066634e509988232b435cf2e64c778ec4508a4b4) | `maintainers: add myself (bobby285271) to the GNOME team`                |
| [`978da552`](https://github.com/NixOS/nixpkgs/commit/978da552e5728d10b73610d0b26058bb1277f20f) | `dasel: 1.24.0 -> 1.24.1`                                                |
| [`6cdf6954`](https://github.com/NixOS/nixpkgs/commit/6cdf69546b32b657fd64e9d2aa48d4a25c809fef) | `firefox: allow RDD sandbox access to gpu drivers`                       |
| [`3ea0bebd`](https://github.com/NixOS/nixpkgs/commit/3ea0bebd9ec5fa8c63ebccfdd03a3b52fad35d20) | `gnome.gnome-logs: 3.36.0 → 42.0`                                        |
| [`e9252627`](https://github.com/NixOS/nixpkgs/commit/e92526274d79415b9f8b6623af23b3952f7119cb) | `python39Packages.libcst: switch to pytestCheckHook, remove linters`     |