### PR TITLE
chore(flake/fenix): `985a64f6` -> `c043ece6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1648707977,
-        "narHash": "sha256-b8d0KyogxhyBEGFwPIG8lub/5YxkFybN4Htl/h2Ihqg=",
+        "lastModified": 1651300005,
+        "narHash": "sha256-Qj5mR4Db0pvuC69tCfuikS97W4B2TZRoMrhxILZGY40=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "985a64f6ac2c1f36d7cd7076096f9fdbf1eae0b7",
+        "rev": "c043ece6b0a48c384bcdaf7b80851b97d50b13d4",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1648648130,
-        "narHash": "sha256-i7PNH20SGr0w3tP4ipIRhaK21IYo66y1YdYW+5HcJ/8=",
+        "lastModified": 1651234072,
+        "narHash": "sha256-i0G0brnVCe82OtWlfLWeMfhDLmtuqN4nOH5HKXLwp8E=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "259182b50b131647975926e8c94aad4c47d33747",
+        "rev": "c6995a372f48afb40e2657defb448312281be8ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`c043ece6`](https://github.com/nix-community/fenix/commit/c043ece6b0a48c384bcdaf7b80851b97d50b13d4) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`762cc26a`](https://github.com/nix-community/fenix/commit/762cc26ae995ee9c46e4aa36951dd29971cd9770) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b83496f2`](https://github.com/nix-community/fenix/commit/b83496f2d1267d8ccf8119c18db1e5e66b22d3b2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`22d6b677`](https://github.com/nix-community/fenix/commit/22d6b677d04b63f5e5c5bd8ed15d16a2146314a6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`9153efa4`](https://github.com/nix-community/fenix/commit/9153efa4a318b11e4315b79f92ac4dc9c666ef6a) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`77bdcbf6`](https://github.com/nix-community/fenix/commit/77bdcbf63373b5b0ceb6e07d60d0cc98b23b1a9e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`ee939100`](https://github.com/nix-community/fenix/commit/ee93910033cfaec7286938e89874ce4ea83aed69) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`810a7995`](https://github.com/nix-community/fenix/commit/810a7995095ace63238977d3659852adba649a75) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2dad3a32`](https://github.com/nix-community/fenix/commit/2dad3a32778fe15c5b215e9168c008879fac891b) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fd9fb1fb`](https://github.com/nix-community/fenix/commit/fd9fb1fb652e22bce0a3695f8b5e0f8df3be4eb6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`6265516f`](https://github.com/nix-community/fenix/commit/6265516f6874bdd6b15904fe8483200cf9a07fe2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`557a4bd1`](https://github.com/nix-community/fenix/commit/557a4bd15fb08ccf15b50b67ce6e95a0958cbf2f) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2d5a1021`](https://github.com/nix-community/fenix/commit/2d5a1021b48667d4dc470f9f6da0d4bbad1c2abb) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`088fff62`](https://github.com/nix-community/fenix/commit/088fff62814e9a92062534ceba92d98114efdd94) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`5cbb7720`](https://github.com/nix-community/fenix/commit/5cbb7720dcbb684fd8375fdd915fb725a6c2178b) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`1d50f015`](https://github.com/nix-community/fenix/commit/1d50f0152aabfb527e90488ed18d9e22190f14cf) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`09118026`](https://github.com/nix-community/fenix/commit/09118026c98a047ec124863f03369daa729dd3d5) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d0046c22`](https://github.com/nix-community/fenix/commit/d0046c22207da60cef1297802a406738357fe2a6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fcaa8dcc`](https://github.com/nix-community/fenix/commit/fcaa8dcce2b30383233c2db7424489dce4f6999e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`ffb14964`](https://github.com/nix-community/fenix/commit/ffb14964b27a778c14da5878f4c08e0388dbcc79) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`e9b68fc2`](https://github.com/nix-community/fenix/commit/e9b68fc2d9cf198769d5ebfd86e80874d9965025) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`79579e5b`](https://github.com/nix-community/fenix/commit/79579e5b5dd363fa37f725151d739cb1c629f52b) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b768a083`](https://github.com/nix-community/fenix/commit/b768a0832d20ff44de6348d95938d5a539e475c2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`0bb81a7b`](https://github.com/nix-community/fenix/commit/0bb81a7b1226a28b5453eff676683789561bc7ca) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`c7e18456`](https://github.com/nix-community/fenix/commit/c7e184561fe843abb861cd7d22c23066987078e2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2af3ac5c`](https://github.com/nix-community/fenix/commit/2af3ac5c6ee0e353e055241e21ca4710714a1394) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`a772c7c4`](https://github.com/nix-community/fenix/commit/a772c7c4f8bcf45fb1767df2bf13a66f8ff81841) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`30cd38e6`](https://github.com/nix-community/fenix/commit/30cd38e6358ac9026edcf8f5b7ee1809bc972425) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`815db84b`](https://github.com/nix-community/fenix/commit/815db84bb0e7363acc28cc9419fe2c4c1d2a88a2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`7cadbf5e`](https://github.com/nix-community/fenix/commit/7cadbf5e02367ac445c8b416f56589a28e32c380) | `update: rust toolchains, rust analyzer, flake.lock` |