### PR TITLE
chore(flake/flake-compat): `64a525ee` -> `b4a34015`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message      |
| ------------------------------------------------------------------------------------------------------ | ------------------- |
| [`246e8851`](https://github.com/edolstra/flake-compat/commit/246e8851305963be549af62095d4b7211a742db0) | `Quote url literal` |