### PR TITLE
chore(flake/naersk): `e30ef9a5` -> `e8f9f8d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648544490,
-        "narHash": "sha256-EoBDcccV70tfz2LAs5lK0BjC7en5mzUVlgLsd5E6DW4=",
+        "lastModified": 1650265945,
+        "narHash": "sha256-SO8+1db4jTOjnwP++29vVgImLIfETSXyoz0FuLkiikE=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "e30ef9a5ce9b3de8bb438f15829c50f9525ca730",
+        "rev": "e8f9f8d037774becd82fce2781e1abdb7836d7df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`e8f9f8d0`](https://github.com/nix-community/naersk/commit/e8f9f8d037774becd82fce2781e1abdb7836d7df) | `Support dependencies with slashes in their names`                                  |
| [`8cc37947`](https://github.com/nix-community/naersk/commit/8cc379478819e6a22ce7595a761fe1e17c8d7458) | `chore: Add myself to .github/CODEOWNERS`                                           |
| [`d626f733`](https://github.com/nix-community/naersk/commit/d626f73332a8f587b613b0afe7293dd0777be07d) | `code review: allRefs -> gitAllRefs, refresh README`                                |
| [`4c9c2753`](https://github.com/nix-community/naersk/commit/4c9c275343a0b46d019a1217204b6e9ae3caee41) | `build: unpack only named git deps (#1)`                                            |
| [`99c7fce6`](https://github.com/nix-community/naersk/commit/99c7fce671f2d93c468204178b8b2291088fade0) | `feat: optional submodule fetching`                                                 |
| [`8be5c005`](https://github.com/nix-community/naersk/commit/8be5c0059de6f1ee7ae7d2a3ac4883f8c33ed963) | `feat: simplify git dependency detection by only using cargo lock, allRefs support` |