### PR TITLE
chore(flake/naersk): `e8f9f8d0` -> `69daacee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650265945,
-        "narHash": "sha256-SO8+1db4jTOjnwP++29vVgImLIfETSXyoz0FuLkiikE=",
+        "lastModified": 1653413650,
+        "narHash": "sha256-wojDHjb+eU80MPH+3HQaK0liUy8EgR95rvmCl24i58Y=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "e8f9f8d037774becd82fce2781e1abdb7836d7df",
+        "rev": "69daaceebe12c070cd5ae69ba38f277bbf033695",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`69daacee`](https://github.com/nix-community/naersk/commit/69daaceebe12c070cd5ae69ba38f277bbf033695) | `Make dummy-src respect cargo fmt`             |
| [`94beb7a3`](https://github.com/nix-community/naersk/commit/94beb7a3edfeb3bcda65fa3f2ebc48ec6b40bf72) | ``Add support for the `postInstall` hook``     |
| [`66883c7d`](https://github.com/nix-community/naersk/commit/66883c7d6dff61386a806ae59e9dd5eaacf706cf) | `readme: Fix ./script/gen`                     |
| [`f21309b3`](https://github.com/nix-community/naersk/commit/f21309b38e1da0d61b881b6b6d41b81c1aed4e1d) | `refactor: Refactor tests into separate files` |