### PR TITLE
chore(flake/fenix): `c043ece6` -> `b39048a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1651300005,
-        "narHash": "sha256-Qj5mR4Db0pvuC69tCfuikS97W4B2TZRoMrhxILZGY40=",
+        "lastModified": 1653978486,
+        "narHash": "sha256-8TpFVaCgyFAo6x9SYxaEeRsYGrE77pKUJJeoFVUx0+I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c043ece6b0a48c384bcdaf7b80851b97d50b13d4",
+        "rev": "b39048a693e77ae77846aa7b351be7d3cacb8340",
         "type": "github"
       },
       "original": {
@@ -121,15 +121,15 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1651234072,
-        "narHash": "sha256-i0G0brnVCe82OtWlfLWeMfhDLmtuqN4nOH5HKXLwp8E=",
-        "owner": "rust-analyzer",
+        "lastModified": 1653919537,
+        "narHash": "sha256-SasAyTjxvSRlP5istn8MealvR6qpBKYx3nNdAqUe/o8=",
+        "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "c6995a372f48afb40e2657defb448312281be8ad",
+        "rev": "a5d7ab54f950d197d79b8f9739016f18a93bc491",
         "type": "github"
       },
       "original": {
-        "owner": "rust-analyzer",
+        "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
         "type": "github"


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                              |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b39048a6`](https://github.com/nix-community/fenix/commit/b39048a693e77ae77846aa7b351be7d3cacb8340) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`2274b8fe`](https://github.com/nix-community/fenix/commit/2274b8fe08d8e98bb631a705291afa079f4290ea) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`f7d9e465`](https://github.com/nix-community/fenix/commit/f7d9e465f6683eed209d5dfef361d14adaef9ac6) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`83a0ee71`](https://github.com/nix-community/fenix/commit/83a0ee712cd6efaba80588913afb1c149657da7f) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`38ac2a40`](https://github.com/nix-community/fenix/commit/38ac2a402ee55bd2f5df27663c0e913bc8cab49c) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`29465885`](https://github.com/nix-community/fenix/commit/294658858287ef0ecc4e321c21c38e5b32c5c36a) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`9a49d754`](https://github.com/nix-community/fenix/commit/9a49d754de250ad696e49c9ae4ce4561ffe3fc38) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`520c4d4d`](https://github.com/nix-community/fenix/commit/520c4d4d54bd8614d4493c9c1d3952e32d801096) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`66fb5062`](https://github.com/nix-community/fenix/commit/66fb506299ec96d61a5b692e907229322f5206a4) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`4853925d`](https://github.com/nix-community/fenix/commit/4853925d5169226c72d9f93b9feacff0250b1959) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`e3b401ca`](https://github.com/nix-community/fenix/commit/e3b401ca3ea0b553e2e3db52feb00e0fa8c31996) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`77d3fdf1`](https://github.com/nix-community/fenix/commit/77d3fdf1594bd0fb9ce8e874bc832391e4194374) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`2ce452cb`](https://github.com/nix-community/fenix/commit/2ce452cb4d71e52fc4f798867780d1822be0abb1) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`88728201`](https://github.com/nix-community/fenix/commit/88728201231300347135b37132a8546769c5249a) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`edee58e4`](https://github.com/nix-community/fenix/commit/edee58e49e6498a1142efd02a1f5a12a90770014) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`dc66463d`](https://github.com/nix-community/fenix/commit/dc66463dbeb5a9393190821b911953a109021755) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`55a5e7bf`](https://github.com/nix-community/fenix/commit/55a5e7bf43cb2512e6aece812111025f75d7121e) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`39cba6b6`](https://github.com/nix-community/fenix/commit/39cba6b66a005bfb62d46f8b108cf844adb097e9) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`1cec27b3`](https://github.com/nix-community/fenix/commit/1cec27b3a6ebb4d16fd81c5b816edbe4147518ba) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`26f7a34f`](https://github.com/nix-community/fenix/commit/26f7a34feeb2cae057b98d499f92c20ce161440d) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`ba2c30d8`](https://github.com/nix-community/fenix/commit/ba2c30d899753c875bd882216a137a61abf61eb3) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`1ae915cd`](https://github.com/nix-community/fenix/commit/1ae915cd731314a53c3c37d78655d9c6f34f7468) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`4fd8f4e9`](https://github.com/nix-community/fenix/commit/4fd8f4e9ccc72d82b1f79ab2ab00a95adb12169c) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`4c2db5e4`](https://github.com/nix-community/fenix/commit/4c2db5e42091eac93d6511d4d963d76c17716f6b) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`fc75cd2a`](https://github.com/nix-community/fenix/commit/fc75cd2a04c398c7f7f77e44b09776bf74198708) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`a43a475f`](https://github.com/nix-community/fenix/commit/a43a475f0854a9923271da3c8a960e2461114ead) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`4b6dda75`](https://github.com/nix-community/fenix/commit/4b6dda7529e6d1d8d2ce43b7cb18efdefd5c4c3c) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`7e75d8af`](https://github.com/nix-community/fenix/commit/7e75d8af9165305d2c96fed2b79322a170b6bf03) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`60d8facc`](https://github.com/nix-community/fenix/commit/60d8facc23af3d32917790526e72ff6b34f48885) | `build(deps): bump cachix/install-nix-action from 16 to 17` |
| [`8d646b45`](https://github.com/nix-community/fenix/commit/8d646b4562bc95f4dbc70dbd475bfaa28b465fc1) | `github actions: remove comment`                            |
| [`5319a4a9`](https://github.com/nix-community/fenix/commit/5319a4a9d14fdf8f7b9a355c9192e48dfe60bb81) | `github actions: add access token for pr, clean up`         |
| [`2663af10`](https://github.com/nix-community/fenix/commit/2663af10fcf46fb42f823035337aa5653b3cd41d) | `Update rust-analyzer GitHub repository lookup`             |
| [`967ae040`](https://github.com/nix-community/fenix/commit/967ae0401146078e3e96a76e5517e1976e4d91c7) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`706bcb31`](https://github.com/nix-community/fenix/commit/706bcb3114957b2ccbf366a86f752cd277a5286a) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`baa2fefe`](https://github.com/nix-community/fenix/commit/baa2fefecd746a0a02d43eb11c930d3c0dee6753) | `update: rust toolchains, rust analyzer, flake.lock`        |
| [`c1a1b067`](https://github.com/nix-community/fenix/commit/c1a1b0672de1154c2111884702bbb8d028b11a79) | ``lib.toolchain: set rpath for `rustlib/*/bin` binaries``   |