### PR TITLE
chore(flake/naersk): `69daacee` -> `cddffb5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653413650,
-        "narHash": "sha256-wojDHjb+eU80MPH+3HQaK0liUy8EgR95rvmCl24i58Y=",
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "69daaceebe12c070cd5ae69ba38f277bbf033695",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                             |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`cddffb5a`](https://github.com/nix-community/naersk/commit/cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f) | `remove fetchGit allRefs flag for nix <2.4`                                |
| [`e300ddf8`](https://github.com/nix-community/naersk/commit/e300ddf8cbb694efbe9775b6cc500e186fdf317d) | `force fetchGit allRefs when a dependency is specified with "rev"`         |
| [`14997a79`](https://github.com/nix-community/naersk/commit/14997a79cd78fe34ad6390f18a327ee0593e5eec) | `Bump spin from 0.5.0 to 0.5.2 in /test/fast/workspace/fixtures`           |
| [`af8ba735`](https://github.com/nix-community/naersk/commit/af8ba73597d9596afe0e8691c033ec742dbf5620) | `Bump regex from 1.1.8 to 1.5.5 in /test/fast/workspace-patched/fixtures`  |
| [`5b76e39b`](https://github.com/nix-community/naersk/commit/5b76e39b2a9bb16d1a763849e33312f04d9371bf) | `Bump regex from 1.1.8 to 1.5.5 in /test/fast/simple-dep/fixtures`         |
| [`1eb62c04`](https://github.com/nix-community/naersk/commit/1eb62c040d4581ef13bddcfa788ca291bfcd8eb4) | `Bump spin from 0.5.0 to 0.5.2 in /test/fast/simple-dep/fixtures`          |
| [`97ed834a`](https://github.com/nix-community/naersk/commit/97ed834a8673adcd168ae07d0a5d81544beeb352) | `Bump regex from 1.1.8 to 1.5.5 in /test/fast/workspace/fixtures`          |
| [`138faef4`](https://github.com/nix-community/naersk/commit/138faef4219e7d40c8b3e24da0d4526a4e69875c) | `Bump regex from 1.3.1 to 1.5.5 in /test/fast/dummyfication/fixtures`      |
| [`059feac0`](https://github.com/nix-community/naersk/commit/059feac06f9e9dfd180bf04fd1b3cf21e07d48fb) | `Bump regex from 1.1.8 to 1.5.5 in /test/fast/simple-dep-patched/fixtures` |