### PR TITLE
chore(flake/fenix): `b39048a6` -> `47f9bff2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1653978486,
-        "narHash": "sha256-8TpFVaCgyFAo6x9SYxaEeRsYGrE77pKUJJeoFVUx0+I=",
+        "lastModified": 1656570463,
+        "narHash": "sha256-jDoY23BRZ/lE+yB5as7qoevLs0T1nfBJMYJzIFIy3sE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "b39048a693e77ae77846aa7b351be7d3cacb8340",
+        "rev": "47f9bff2d9ea48977b1c9565844e1f3be6deee15",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1653919537,
-        "narHash": "sha256-SasAyTjxvSRlP5istn8MealvR6qpBKYx3nNdAqUe/o8=",
+        "lastModified": 1656443930,
+        "narHash": "sha256-IcUo9c6qaH9h2XSpbwooH/OsxS3n13OVMPT9LWT7TFU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "a5d7ab54f950d197d79b8f9739016f18a93bc491",
+        "rev": "b0102bd469a0d9d5008ce3b5ae0fa1f13e8d18d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`47f9bff2`](https://github.com/nix-community/fenix/commit/47f9bff2d9ea48977b1c9565844e1f3be6deee15) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fcebd1ee`](https://github.com/nix-community/fenix/commit/fcebd1ee223b2ca90f099fee132c54769c236e05) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`3094da92`](https://github.com/nix-community/fenix/commit/3094da922a89a7dfb019224241987abb297951d0) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`5e2708f0`](https://github.com/nix-community/fenix/commit/5e2708f04efe0ed2616be471d0913e303ff3a9ee) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`a5b11b8d`](https://github.com/nix-community/fenix/commit/a5b11b8d6bce93078491465193e41df15583ade7) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2f1c9a04`](https://github.com/nix-community/fenix/commit/2f1c9a040c790f9ed13ae933b748a55578138777) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8b4accdb`](https://github.com/nix-community/fenix/commit/8b4accdb9dfec0d309e0e6d8d53a7014686a6b86) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`dd9e9290`](https://github.com/nix-community/fenix/commit/dd9e9290d17f5539d2a5dd8235a281336d806487) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`e5d30727`](https://github.com/nix-community/fenix/commit/e5d307272ac4540df27d0ea96949a6df359dc2a2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`61fdbf76`](https://github.com/nix-community/fenix/commit/61fdbf7664f44e13a9c0c94c1bb561e4db5f5af3) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d895003d`](https://github.com/nix-community/fenix/commit/d895003d8e03ac2fc8ffe2aa898299cbef1a7048) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`55987185`](https://github.com/nix-community/fenix/commit/55987185def5cf3afc616d38907406293a170cfe) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b6630603`](https://github.com/nix-community/fenix/commit/b6630603af13df17d0dd4df8629e9a24e6ba0fbd) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`d6c64bae`](https://github.com/nix-community/fenix/commit/d6c64baead8188be7d83069d51897b61068e4c3d) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`720b5426`](https://github.com/nix-community/fenix/commit/720b54260dee864d2a21745bd2bb55223f58e297) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`2278b01f`](https://github.com/nix-community/fenix/commit/2278b01fe743e02b4a5d3d88f78d6492d497f2cd) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`522a4e99`](https://github.com/nix-community/fenix/commit/522a4e99be1f8fcc94b94666c3a44677d668f539) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`f90a687d`](https://github.com/nix-community/fenix/commit/f90a687d4f8a29ed1774f482a5fc9d8409687a43) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`17eb24f2`](https://github.com/nix-community/fenix/commit/17eb24f27c42709ec984b9737bd633685d1084b2) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`592e9c0c`](https://github.com/nix-community/fenix/commit/592e9c0c0f1ee0906f7e17ea316acfbca3a3fc02) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`ccd2a080`](https://github.com/nix-community/fenix/commit/ccd2a0808b160e7236bcc0c89749ec5b44749703) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`fcf7d902`](https://github.com/nix-community/fenix/commit/fcf7d9029dab1c4a13aaee009feba7658f415add) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`02664b6e`](https://github.com/nix-community/fenix/commit/02664b6e639f0461e9f03e85707326029776341e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`77b4b557`](https://github.com/nix-community/fenix/commit/77b4b5570afd563d7e2b6b4acb5cd4b040092c20) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`54bbc3b0`](https://github.com/nix-community/fenix/commit/54bbc3b0994a16ab97795e11ac6bb91d96b1b601) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`e4248359`](https://github.com/nix-community/fenix/commit/e4248359f88fd5b421b7ab6a3e73de4d955b018f) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`ff329e04`](https://github.com/nix-community/fenix/commit/ff329e04ab7d2c62de0578ed56b347779498448e) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8dccfbe5`](https://github.com/nix-community/fenix/commit/8dccfbe51a8adea643ec29a4ec516499a5a081c6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`b2ba32f3`](https://github.com/nix-community/fenix/commit/b2ba32f32e5238b4c6b49f81ff3d82e4dbe7f728) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`8cfd5b7d`](https://github.com/nix-community/fenix/commit/8cfd5b7dec932d891355b36c7dd644af431150b6) | `update: rust toolchains, rust analyzer, flake.lock` |
| [`330cfaeb`](https://github.com/nix-community/fenix/commit/330cfaeb3721ad0a098831ef4fa51b092c18606b) | `Fix RUST_SRC_PATH comment`                          |