### PR TITLE
chore(flake/nixpkgs): `49a2bcc6` -> `f72be3af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654012153,
-        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
+        "lastModified": 1656585567,
+        "narHash": "sha256-i+IY2Dklg3WhIl43iznyAdwtNi7xuIgMUdpJPn3uRuU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
+        "rev": "f72be3af76fb7dc45e2088d8cb9aba1e6767a930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`b44f6df4`](https://github.com/NixOS/nixpkgs/commit/b44f6df49725d9d968dc14e97cfcb0d21f8368d3) | `nix-update: 0.5.1 -> 0.6.0`                                                        |
| [`a1aed2a7`](https://github.com/NixOS/nixpkgs/commit/a1aed2a716ff3471f91f0ba57f551335202df98b) | `builders/writeHaskell: build with threaded GHC runtime`                            |
| [`7f3cdfd2`](https://github.com/NixOS/nixpkgs/commit/7f3cdfd2ba5a05a2d413c2cd9c421a4b0a28ac94) | `dtc: fix static building`                                                          |
| [`41d9b090`](https://github.com/NixOS/nixpkgs/commit/41d9b0908c4068f17a2d528e2e920d2146aa4925) | `python310Packages.nextcord: 2.0.0b3 -> 2.0.0`                                      |
| [`d3248619`](https://github.com/NixOS/nixpkgs/commit/d3248619647234b5dc74a6921bcdf6dd8323eb22) | `python310Packages.python-telegram-bot: 13.12 -> 13.13 (#179588)`                   |
| [`ba533129`](https://github.com/NixOS/nixpkgs/commit/ba533129002f7fc5974df424679c4a3a8d4d3520) | `python310Packages.sanic-testing: 22.3.0 -> 22.3.1`                                 |
| [`ccef4ede`](https://github.com/NixOS/nixpkgs/commit/ccef4edeaf5175edb5c6a9fa3f81c7d833fb69d5) | `python310Packages.sagemaker: 2.96.0 -> 2.97.0`                                     |
| [`c7b135ac`](https://github.com/NixOS/nixpkgs/commit/c7b135ac8ebf53e4e2c94cc9340f6199801d42e4) | `cachix-agent: properly handle not restarting the service`                          |
| [`af384e15`](https://github.com/NixOS/nixpkgs/commit/af384e15ae4a97df75510fefea547e8664f3a488) | `runitor: drop unused input`                                                        |
| [`97d398eb`](https://github.com/NixOS/nixpkgs/commit/97d398eb2a768fca806d56a978aa09573e3bf40b) | `terraform: 1.2.3 -> 1.2.4`                                                         |
| [`1419d299`](https://github.com/NixOS/nixpkgs/commit/1419d299069dfcdc1c34871128456b774b5db5b8) | `opencpn: unalias epoxy`                                                            |
| [`d27e6f2d`](https://github.com/NixOS/nixpkgs/commit/d27e6f2d052214b21cbbbe2efc6ab46615ae3ee5) | `haskellPackages: Unalias RunCommandNoCCLocal`                                      |
| [`021cf726`](https://github.com/NixOS/nixpkgs/commit/021cf726fcd54fa47f5c5b78f8b897ddfb878b73) | `python310Packages.cartopy: 0.20.2 -> 0.20.3`                                       |
| [`f804d136`](https://github.com/NixOS/nixpkgs/commit/f804d136074bb3ad43c8d3d2f83349044769603c) | `python310Packages.json-schema-for-humans: 0.41.1 -> 0.41.3`                        |
| [`85afe973`](https://github.com/NixOS/nixpkgs/commit/85afe9737c7182185cfdaaeedefb2d10a3641aa6) | `sov: fix default config location (#178882)`                                        |
| [`f14b6f55`](https://github.com/NixOS/nixpkgs/commit/f14b6f553a7721b963cf10048adf35d08d5d0253) | `javacc: fix meta.maintainers`                                                      |
| [`eda6d6e0`](https://github.com/NixOS/nixpkgs/commit/eda6d6e075d4dc71638265d39f6c0157d76aa7bd) | `libsForQt5.drumstick: 2.5.1 -> 2.6.1`                                              |
| [`b0e82c68`](https://github.com/NixOS/nixpkgs/commit/b0e82c6809e51123a2e152cc6353b317210ea88b) | `xfsdump: fix build against xfsprogs 5.18.0`                                        |
| [`028af6dd`](https://github.com/NixOS/nixpkgs/commit/028af6dd4a5b08333fead4d20023aa181d8a1bb4) | `python310Packages.karton-mwdb-reporter: unstable-2022-02-22 -> 1.1.0`              |
| [`dd52d403`](https://github.com/NixOS/nixpkgs/commit/dd52d403671974d1a89e1b723a593c91528e2995) | `deadbeefPlugins.playlist-manager: init at unstable-2021-05-02`                     |
| [`5bec894d`](https://github.com/NixOS/nixpkgs/commit/5bec894dc12d68a95f764009c7187c057601e58e) | `deadbeefPlugins.mpris2: 1.12 -> 1.14`                                              |
| [`b0f64184`](https://github.com/NixOS/nixpkgs/commit/b0f641840bfb2ab04c8d15e1a68742b516594776) | `deadbeef: 1.8.4 -> 1.9.1`                                                          |
| [`ad892591`](https://github.com/NixOS/nixpkgs/commit/ad892591a583c30df6c99331f8c42b5424df4e56) | `swift-corelibs-libdispatch: init at swift-5.5-RELEASE`                             |
| [`7b410b13`](https://github.com/NixOS/nixpkgs/commit/7b410b13eeff35506bf581997d37731572e0fbda) | `ocamlPackages.ke: 0.4 → 0.6`                                                       |
| [`411074a6`](https://github.com/NixOS/nixpkgs/commit/411074a6ef78e464609f0fcd591a15aa972711a1) | `haxePackages.heaps: init at 1.9.1`                                                 |
| [`b1987d77`](https://github.com/NixOS/nixpkgs/commit/b1987d775203691b820f8c4bc793fb6dc0111f24) | `haxePackages.hlsdl: init at 1.10.0`                                                |
| [`45da69f6`](https://github.com/NixOS/nixpkgs/commit/45da69f65eea3a7e097effb35f2318a2c98d23ac) | `haxePackages.hlopenal: init at 1.5.0`                                              |
| [`cd4eeacc`](https://github.com/NixOS/nixpkgs/commit/cd4eeacc7e78552d8d48674df42db18190073087) | `haxePackages.format: init at 3.5.0`                                                |
| [`9d7932e3`](https://github.com/NixOS/nixpkgs/commit/9d7932e349942db74ec2c3a7030085c77d7a3716) | `fastly: init at 3.1.0`                                                             |
| [`12f818e3`](https://github.com/NixOS/nixpkgs/commit/12f818e3045279745a4d52da9aa293398e221a42) | `erofs-utils: 1.4 -> 1.5`                                                           |
| [`bb6885f3`](https://github.com/NixOS/nixpkgs/commit/bb6885f3f386c9a674c4603b73da07986755800d) | `gnunet: 0.16.3 -> 0.17.1`                                                          |
| [`aaa1cf94`](https://github.com/NixOS/nixpkgs/commit/aaa1cf94f9d83a8c75bcea76ef62b6fe8f1acf85) | `scribus: 1.5.7 -> 1.5.8`                                                           |
| [`08ddd8a5`](https://github.com/NixOS/nixpkgs/commit/08ddd8a5fcbd4f0cc872304035e54a21fbcbb321) | `nixos-generate-config: detect parallels virtualization`                            |
| [`5f63ac02`](https://github.com/NixOS/nixpkgs/commit/5f63ac02e36ef6528814d9aa4fb1dfee2c538c96) | `pkgsMusl.libical: fix build by disabling tests`                                    |
| [`64f50578`](https://github.com/NixOS/nixpkgs/commit/64f5057853fea5d7b30b69a210364d516ebf512c) | `traefik: 2.7.1 -> 2.7.2`                                                           |
| [`4e63de22`](https://github.com/NixOS/nixpkgs/commit/4e63de22e2fd2c3409a6d3bb3a0d0e4688d6c16a) | `python310Packages.boxx: 0.10.1 -> 0.10.4`                                          |
| [`546489d0`](https://github.com/NixOS/nixpkgs/commit/546489d01756f83bf085396a9ef728accaa4fa2b) | `maintainers: add snapdgn`                                                          |
| [`bdf9ab61`](https://github.com/NixOS/nixpkgs/commit/bdf9ab616a53e0e5ea2c3dc9d388a5c7a68d0478) | `n8n: 0.182.1 → 0.184.0`                                                            |
| [`54aa5269`](https://github.com/NixOS/nixpkgs/commit/54aa52698d1025e1c3456d02c5e8e0df44343efc) | `python310Packages.pygtkspellcheck: 4.0.6 -> 5.0.0`                                 |
| [`f5dfb9a0`](https://github.com/NixOS/nixpkgs/commit/f5dfb9a0d47fc3699dc5b096d5aa9f62e0163c58) | `sile: 0.13.1 → 0.13.2`                                                             |
| [`e6b696e3`](https://github.com/NixOS/nixpkgs/commit/e6b696e3e2e34fd001ed3070a5b7642c142bfe15) | `python310Packages.peaqevcore: 2.0.2 -> 2.1.1`                                      |
| [`02cc4494`](https://github.com/NixOS/nixpkgs/commit/02cc44949cbac7a4500a0e2e20f91c740d7cfe72) | `python310Packages.homeconnect: 0.7.0 -> 0.7.1`                                     |
| [`b4fe5adb`](https://github.com/NixOS/nixpkgs/commit/b4fe5adbddf1a2307177e14e9335283822abf0a4) | `python310Packages.simplisafe-python: 2022.06.0 -> 2022.06.1`                       |
| [`008ccf30`](https://github.com/NixOS/nixpkgs/commit/008ccf301f3dd2bf48fd64395f645eef448989fd) | `python310Packages.xknx: 0.21.4 -> 0.21.5`                                          |
| [`3e3ee91e`](https://github.com/NixOS/nixpkgs/commit/3e3ee91e933dd94ab2f70aa1f9bd6a76f68ec965) | `python310Packages.pynetgear: 0.10.5 -> 0.10.6`                                     |
| [`fb3101b2`](https://github.com/NixOS/nixpkgs/commit/fb3101b204c7639bea7aa763d8e670bafb00b8bf) | `python310Packages.weconnect-mqtt: 0.35.0 -> 0.37.2`                                |
| [`fd7dff9e`](https://github.com/NixOS/nixpkgs/commit/fd7dff9ea3c9b6b99d141149bf75c08dde7d7863) | `python310Packages.weconnect: 0.41.0 -> 0.44.2`                                     |
| [`e0b0dcb9`](https://github.com/NixOS/nixpkgs/commit/e0b0dcb982c677b524182fdcc34f727c360beee1) | `exploitdb: 2022-06-15 -> 2022-06-28`                                               |
| [`78dd1e59`](https://github.com/NixOS/nixpkgs/commit/78dd1e59029f2c4614b6e1dad25b10a233af8afa) | `python310Packages.bc-python-hcl2: 0.3.43 -> 0.3.44`                                |
| [`85856bae`](https://github.com/NixOS/nixpkgs/commit/85856baed353fece78a21767dd2da33afbbb063b) | `python310Packages.angr: 9.2.7 -> 9.2.8`                                            |
| [`18006322`](https://github.com/NixOS/nixpkgs/commit/1800632205d34f4b535a234cb5844bc257810e50) | `python310Packages.cle: 9.2.7 -> 9.2.8`                                             |
| [`79076ad5`](https://github.com/NixOS/nixpkgs/commit/79076ad5ba57adfcc53f7395a4299710037884c6) | `python310Packages.claripy: 9.2.7 -> 9.2.8`                                         |
| [`ac98e19d`](https://github.com/NixOS/nixpkgs/commit/ac98e19d1fb862a719f046d44800eca8c20b8a88) | `python310Packages.pyvex: 9.2.7 -> 9.2.8`                                           |
| [`3529b5d6`](https://github.com/NixOS/nixpkgs/commit/3529b5d67d17c8510a4bfdff4a752f0273205489) | `python310Packages.ailment: 9.2.7 -> 9.2.8`                                         |
| [`e8ac7b9c`](https://github.com/NixOS/nixpkgs/commit/e8ac7b9cc6d77519828583f9248a831c69191fb7) | `python310Packages.archinfo: 9.2.7 -> 9.2.8`                                        |
| [`6a0effc6`](https://github.com/NixOS/nixpkgs/commit/6a0effc6f04fada686c8047e5567ab1a5b0d0870) | `python310Packages.rzpipe: 0.1.2 -> 0.4.0`                                          |
| [`67512d03`](https://github.com/NixOS/nixpkgs/commit/67512d036de4df47e72bb6e9fa91520dfb6c5ce2) | `checkov: 2.1.10 -> 2.1.16`                                                         |
| [`96fb180e`](https://github.com/NixOS/nixpkgs/commit/96fb180e8218ed7f5c96a43c0646c012de759e62) | `python310Packages.zha-quirks: 0.0.75 -> 0.0.77`                                    |
| [`b607d51a`](https://github.com/NixOS/nixpkgs/commit/b607d51a88efe300aa199f4ce382c2ab24693347) | `changelogger: init at 0.5.2`                                                       |
| [`910a91e0`](https://github.com/NixOS/nixpkgs/commit/910a91e05c89d6aeecb5b947dcfefda4c9e4e617) | `yt-dlp: 2022.6.22.1 -> 2022.6.29`                                                  |
| [`e1eb35fb`](https://github.com/NixOS/nixpkgs/commit/e1eb35fb793739b4a3468efcac23fe67c45eb323) | `python310Packages.dremel3dpy: 2.0.1 -> 2.1.1`                                      |
| [`bed0a7d1`](https://github.com/NixOS/nixpkgs/commit/bed0a7d1163cc2edd559eb559aab2aed28351917) | `gallery-dl: 1.22.1 -> 1.22.3`                                                      |
| [`2338fffa`](https://github.com/NixOS/nixpkgs/commit/2338fffa0f9478cb19893c8262618d3df59e5bd1) | `gvm-tools: 22.6.0 -> 22.6.1`                                                       |
| [`95a7f024`](https://github.com/NixOS/nixpkgs/commit/95a7f0244aa8b935d84e4a3b7ee8090ce9c00caa) | `datadog-agent: make systemd optional`                                              |
| [`466b1471`](https://github.com/NixOS/nixpkgs/commit/466b14712f467c962c4c2d89c9c96fc0b9ca0e3c) | `maintainers: remove bjg`                                                           |
| [`d3991bc5`](https://github.com/NixOS/nixpkgs/commit/d3991bc5be2ff874a799c3f4b436b82ead09dab1) | `maintainers: remove lyt`                                                           |
| [`17da0007`](https://github.com/NixOS/nixpkgs/commit/17da0007412f624ada37b772586de8592acbc09b) | `maintainers: remove zef`                                                           |
| [`1bce27ea`](https://github.com/NixOS/nixpkgs/commit/1bce27ea1a12303862d04e87c5c039d4e40cd6e8) | `maintainers: remove Esteth`                                                        |
| [`d26d95d3`](https://github.com/NixOS/nixpkgs/commit/d26d95d39a995798d1cf20c71b7af1a25e0a8b66) | `maintainers: remove miltador`                                                      |
| [`0c35b851`](https://github.com/NixOS/nixpkgs/commit/0c35b851e4988d947d87747feed2c0f7415d2fe5) | `maintainers: remove kkallio`                                                       |
| [`143efb53`](https://github.com/NixOS/nixpkgs/commit/143efb53d6adb6c929338230a71ebdd65f392daf) | `maintainers: remove m3tti`                                                         |
| [`fd75d8c2`](https://github.com/NixOS/nixpkgs/commit/fd75d8c2d398721d1c75df17e3b1d33d315b88ea) | `maintainers: remove chattered`                                                     |
| [`a111cc0c`](https://github.com/NixOS/nixpkgs/commit/a111cc0c2c82852c8aee1bd02de0cc58dae443a0) | `maintainers: remove lrworth`                                                       |
| [`fa32663f`](https://github.com/NixOS/nixpkgs/commit/fa32663f502725015bbb593fa0ebf25bfc5043c8) | `maintainers: remove fuzzy-id`                                                      |
| [`883e38ae`](https://github.com/NixOS/nixpkgs/commit/883e38ae9740b60e554376a8b026fd29e9da4a03) | `maintainers: remove okasu`                                                         |
| [`95d1c563`](https://github.com/NixOS/nixpkgs/commit/95d1c563858fbdcef3b5b56db41a5891dde7e42a) | `maintainers: remove wedens`                                                        |
| [`e23c5a94`](https://github.com/NixOS/nixpkgs/commit/e23c5a9471fce11f27cdbaf4233992c644468df4) | `maintainers: remove funfunctor`                                                    |
| [`9c583f06`](https://github.com/NixOS/nixpkgs/commit/9c583f06af42e39e29ceb8bfbf405d013c79684d) | `maintainers: remove schristo`                                                      |
| [`b67a9bff`](https://github.com/NixOS/nixpkgs/commit/b67a9bffcc8e740217b1984287f49070d7bce499) | `maintainers: remove hinton`                                                        |
| [`3f5b809a`](https://github.com/NixOS/nixpkgs/commit/3f5b809a5fc735cfc3a35752ca6fd67240314d12) | `maintainers: remove sjourdois`                                                     |
| [`d62c3bb2`](https://github.com/NixOS/nixpkgs/commit/d62c3bb22ea458fee4aa0471587bc0b39570e1b1) | `maintainers: remove ravloony`                                                      |
| [`89fbc3fe`](https://github.com/NixOS/nixpkgs/commit/89fbc3fea9844d318410128c463187df5c2f61c0) | `maintainers: remove balajisivaraman`                                               |
| [`45ec5898`](https://github.com/NixOS/nixpkgs/commit/45ec5898cbe01554bc918b6411a85098c2017f78) | `maintainers: remove tstrobel`                                                      |
| [`a8517f95`](https://github.com/NixOS/nixpkgs/commit/a8517f95b85579d7a6c29d2d4d726f1078c68082) | `maintainers: remove joelteon`                                                      |
| [`330f745f`](https://github.com/NixOS/nixpkgs/commit/330f745f6f133f86f1f2ffd6d6c06d115fdf49e1) | `maintainers: remove skrzyp`                                                        |
| [`a2e2f912`](https://github.com/NixOS/nixpkgs/commit/a2e2f9128d11246e690aee4a2e2b2045ac1d1204) | `maintainers: remove markWot`                                                       |
| [`0aac41a5`](https://github.com/NixOS/nixpkgs/commit/0aac41a5d98ea1410f2039d6c8eabc70a8904e2a) | `maintainers: remove winden`                                                        |
| [`4272b643`](https://github.com/NixOS/nixpkgs/commit/4272b6439b874679fcc58fc3af9c58b9251eadc1) | `maintainers: remove willtim`                                                       |
| [`e59cb525`](https://github.com/NixOS/nixpkgs/commit/e59cb525caf1aa7ebb712615d28f93d1f02e77e9) | `maintainers: remove nfjinjing`                                                     |
| [`e966ab39`](https://github.com/NixOS/nixpkgs/commit/e966ab3965a656efdd40b6ae0d8cec6183972edc) | `maintainers: remove all`                                                           |
| [`19e6ace1`](https://github.com/NixOS/nixpkgs/commit/19e6ace19fa5aaf7b854306dd8742f15c4d5c236) | `maintainers: remove epitrochoid`                                                   |
| [`0d5d9c15`](https://github.com/NixOS/nixpkgs/commit/0d5d9c159b1a7c7a62b3266e8b58e9b27d66964f) | `maintainers: remove jwilberding`                                                   |
| [`9966a132`](https://github.com/NixOS/nixpkgs/commit/9966a132db0946702b0bd3ca3114ec02154ab53a) | `maintainers: remove mschneider`                                                    |
| [`246a4998`](https://github.com/NixOS/nixpkgs/commit/246a4998764cb0f50d7918431658bea9ed36c67f) | `maintainers: remove msackman`                                                      |
| [`50084dde`](https://github.com/NixOS/nixpkgs/commit/50084dde4538c3ad9444e8a15220fa4789d3e27b) | `maintainers: remove drewkett`                                                      |
| [`213007a3`](https://github.com/NixOS/nixpkgs/commit/213007a351879ee1b80abc13a3d69136c37af9a9) | `maintainers: remove lattfein`                                                      |
| [`cfd9d640`](https://github.com/NixOS/nixpkgs/commit/cfd9d6405bfdebcfdc34af41c92176efa3d228eb) | `maintainers: remove nslqqq`                                                        |
| [`93039509`](https://github.com/NixOS/nixpkgs/commit/93039509cf31ee3ed70c0ac550b9430f36108805) | `maintainers: remove dasuxullebt`                                                   |
| [`59d8f2b1`](https://github.com/NixOS/nixpkgs/commit/59d8f2b1cd0c4a9cf1e68ab12d0624cba2b7b995) | `maintainers: remove Nate-Devv`                                                     |
| [`3b5f1255`](https://github.com/NixOS/nixpkgs/commit/3b5f12551546cfb019b81c824e299a1e1d383bcf) | `maintainers: remove metabar`                                                       |
| [`be1aefac`](https://github.com/NixOS/nixpkgs/commit/be1aefac05ef7d0bda4d69374edf4822ffa78d99) | `maintainers: remove elyhaka`                                                       |
| [`ff2925fe`](https://github.com/NixOS/nixpkgs/commit/ff2925fe6be230f18c0a7176579797ad0ea4f838) | `maintainers: remove piotr`                                                         |
| [`91b724c6`](https://github.com/NixOS/nixpkgs/commit/91b724c66d81daa60e6e07a285cedcf47d3bd946) | `maintainers: remove danharaj`                                                      |
| [`8cb13668`](https://github.com/NixOS/nixpkgs/commit/8cb1366872c7dc8559b3664d2d2eef1bd741b327) | `maintainers: remove fuwa`                                                          |
| [`92531d85`](https://github.com/NixOS/nixpkgs/commit/92531d8585288da313ecffd2a0b200e1576bb469) | `maintainers: remove bloomvdomino`                                                  |
| [`99466ee3`](https://github.com/NixOS/nixpkgs/commit/99466ee39ebc0696e7fa79f0eaddee71819892eb) | `maintainers: remove petabyteboy`                                                   |
| [`eec156df`](https://github.com/NixOS/nixpkgs/commit/eec156df9c7e1941564bedd625e0f7d176d3ac78) | `maintainers: remove muflax`                                                        |
| [`a0718341`](https://github.com/NixOS/nixpkgs/commit/a0718341e60829bee5c41e51796f4786bc98df81) | `maintainers: remove volth`                                                         |
| [`026ffc38`](https://github.com/NixOS/nixpkgs/commit/026ffc38bd134294ed01ffaa5fb7b6cfabe04371) | `maintainers: remove mehandes`                                                      |
| [`0f55ab1b`](https://github.com/NixOS/nixpkgs/commit/0f55ab1bbc027d66c6aa3c21b3aae41bfd3e6c36) | `maintainers: add missing github details to delta`                                  |
| [`079ba6bd`](https://github.com/NixOS/nixpkgs/commit/079ba6bd0c3546c63d86f90e8f16a5fed083df87) | `maintainers: add missing github details to vq`                                     |
| [`251ef940`](https://github.com/NixOS/nixpkgs/commit/251ef9400d201a8cf53c624cb495a6ae257ae70a) | `maintainers: add missing github handle for lux`                                    |
| [`a4795d32`](https://github.com/NixOS/nixpkgs/commit/a4795d32f700ba60afd5749bac6453f519e5963b) | `maintainers: add missing github details to ivan-tkatchev`                          |
| [`238ac959`](https://github.com/NixOS/nixpkgs/commit/238ac9597cf194772035ba16e0da57d3d33dbfff) | `maintainers: add missing github handle for nessdoor`                               |
| [`cfdec3d0`](https://github.com/NixOS/nixpkgs/commit/cfdec3d079e912e9a6dab4de9aa6cb6411bad70c) | `maintainers: add missing github details to karolchmist`                            |
| [`d7b32a0f`](https://github.com/NixOS/nixpkgs/commit/d7b32a0fc41d0ea2e7c3f6a602d417476c8d3c63) | `maintainers/maintainer-list: fix changed handles`                                  |
| [`b22ac820`](https://github.com/NixOS/nixpkgs/commit/b22ac820c5092d0ec81d7a1f83aa96f943cbc479) | `maintainers/fix-maintainers.pl: init`                                              |
| [`b8383e8c`](https://github.com/NixOS/nixpkgs/commit/b8383e8c90e9d592e952a454fcee63ba58e24688) | `sway-contrib.grimshot: fix meta.maintainers`                                       |
| [`5dc633e7`](https://github.com/NixOS/nixpkgs/commit/5dc633e7d089154f5d3b3dc2990679b617be1219) | `ghidra: fix meta.maintainers`                                                      |
| [`f136e63c`](https://github.com/NixOS/nixpkgs/commit/f136e63c1b1a985be9ea67d2f38735422dc804f8) | `pdfstudio / pdfstudioviewer: 2021.1.3 -> 2021.2.0`                                 |
| [`729764a3`](https://github.com/NixOS/nixpkgs/commit/729764a32d6569e692e44620bd98b552a9f72c33) | `nixos/tests/jitsi-meet: remove grep for successfull health check`                  |
| [`9da7308b`](https://github.com/NixOS/nixpkgs/commit/9da7308bb7e27c37c544d6faf78720c9e80e85c2) | `linux_zen: 5.18.5-zen1 -> 5.18.7-zen1`                                             |
| [`336e11b0`](https://github.com/NixOS/nixpkgs/commit/336e11b0ca9a23cb91b86de9fe61b2f668b6ea3e) | `python3Packages.mkdocs-macros: use python-dateutil directly`                       |
| [`adf52ece`](https://github.com/NixOS/nixpkgs/commit/adf52ecefe4ce0ade9a1b26c6ff876b425a56183) | `linux_lqx: 5.15.16-lqx2 -> 5.18.7-lqx1`                                            |
| [`66c8475a`](https://github.com/NixOS/nixpkgs/commit/66c8475a8ffc7d1432d27e46f61dcbe8a4423b88) | `linux_lqx, linux_zen: add update script`                                           |
| [`aea940da`](https://github.com/NixOS/nixpkgs/commit/aea940da63c27f503915a5ca44cbb9eddf2674f6) | `nixos/jitsi-meet: move prosodyctl calls into prosody preStart`                     |
| [`4d269d11`](https://github.com/NixOS/nixpkgs/commit/4d269d11e351fb52d8c172c4bfa34341d8fccf2a) | `nixos/doc: Fix typo in activation-script.md`                                       |
| [`40674f0d`](https://github.com/NixOS/nixpkgs/commit/40674f0d7f6b06f0b96a6b24cb8d31363a92da86) | `linux_lqx, linux_zen: refactor to unify`                                           |
| [`bf4912f3`](https://github.com/NixOS/nixpkgs/commit/bf4912f39971c85ed3b359dc3b9554b0f8532b42) | `jitsi-meet: 1.0.6155 -> 1.0.6260`                                                  |
| [`bc9c51b9`](https://github.com/NixOS/nixpkgs/commit/bc9c51b90e28c249606458b83ab604d0958aabe2) | `jitsi-videobridge: 2.1-595-g3637fda4 -> 2.2-9-g8cded16e`                           |
| [`cbbdf1bf`](https://github.com/NixOS/nixpkgs/commit/cbbdf1bf7ba3f32fecedb2ef5c5292b212f77909) | `jicofo: 1.0-832 -> 1.0-900`                                                        |
| [`ecb36a7a`](https://github.com/NixOS/nixpkgs/commit/ecb36a7a6fb365ca0a61835855fa513624fe8b6c) | `jitsi-meet-prosody: 1.0.5675 -> 1.0.6260`                                          |
| [`09143afa`](https://github.com/NixOS/nixpkgs/commit/09143afa61a477cb77be43ad3e98284adec39cc0) | `linuxPackages.evdi: enable parallel building`                                      |
| [`d5872d27`](https://github.com/NixOS/nixpkgs/commit/d5872d277c4c6b9e9e51dd525830ff3d88983a55) | `linuxPackages.evdi: 1.10.1 -> 1.11.0`                                              |
| [`2ca99692`](https://github.com/NixOS/nixpkgs/commit/2ca9969237b654b3f147b471ab349de3d27ce9c1) | `thunderbird-bin: 91.10.0 -> 91.11.0`                                               |
| [`caeb4637`](https://github.com/NixOS/nixpkgs/commit/caeb46375d725c0f286e65a797f709f7b64df0eb) | `thunderbird: 91.10.0 -> 91.11.0`                                                   |
| [`65958f1b`](https://github.com/NixOS/nixpkgs/commit/65958f1b046b0f8374994025d508f286f9516c08) | `hyprland: init at 0.6.0beta (#169960)`                                             |
| [`f66f2a44`](https://github.com/NixOS/nixpkgs/commit/f66f2a44cf18f02874e7860a4c6b1b66af1bfc28) | `ncpamixer: 1.3.3.1 -> unstable-2021-10-17`                                         |
| [`e13c5a71`](https://github.com/NixOS/nixpkgs/commit/e13c5a711c1331a8583251028232a2b7f8972373) | `actionlint: 1.6.14 -> 1.6.15`                                                      |
| [`b9ac37a7`](https://github.com/NixOS/nixpkgs/commit/b9ac37a7f970985c2b8c151ab7e688303f78e366) | `python310Packages.google-i18n-address: 2.5.1 -> 2.5.2`                             |
| [`2c1f2657`](https://github.com/NixOS/nixpkgs/commit/2c1f26572f09b73381bc61cf587ab5e29b401727) | `nixos/maintainers: add tomsiewert`                                                 |
| [`0c9bf54b`](https://github.com/NixOS/nixpkgs/commit/0c9bf54b0ca57d6fc59dc17e34e7eadcbe878483) | `python310Packages.pyisy: 3.0.6 -> 3.0.7`                                           |
| [`9381f909`](https://github.com/NixOS/nixpkgs/commit/9381f909cba395de926686c96d165c745769259b) | `python310Packages.mkdocstrings-python: init at 0.7.1`                              |
| [`75bb4716`](https://github.com/NixOS/nixpkgs/commit/75bb471664b7f2a9be6cf2ef4c1add21549550bf) | `python310Packages.griffe: init at 0.21.0`                                          |
| [`c27f94cd`](https://github.com/NixOS/nixpkgs/commit/c27f94cd89167708a56eb8c90e89db05290bcbbd) | `python310Packages.globus-sdk: 3.9.0 -> 3.10.0`                                     |
| [`d1261fa6`](https://github.com/NixOS/nixpkgs/commit/d1261fa63545d08f8529f61657ac306cc2f3012e) | `python310Packages.mkdocstrings: init at 0.19.0`                                    |
| [`d1e0dfd0`](https://github.com/NixOS/nixpkgs/commit/d1e0dfd0f2bf80c5025a344da3ac1127cd24f213) | `python310Packages.mkdocs-autorefs: init 0.4.1`                                     |
| [`8c373a38`](https://github.com/NixOS/nixpkgs/commit/8c373a38ce43793604900c05cc53c382e8114ba8) | `python310Packages.pulumi: remove packages from tests which shouldn't be used`      |
| [`90735c3e`](https://github.com/NixOS/nixpkgs/commit/90735c3e4a2d6d841c3b4263bf88636cffac5f2b) | `python310Packages.schema-salad: use optional-dependencies for black`               |
| [`68aba2a5`](https://github.com/NixOS/nixpkgs/commit/68aba2a58352ba86d01bd939b85b39053d1f1040) | `python310Packages.diagrams: remove black dependency`                               |
| [`b68f5115`](https://github.com/NixOS/nixpkgs/commit/b68f51151277de47d53c01af8ef8aa9276b91d63) | `python310Packages.papermill: convert to pytestCheckHook, remove pytest-cov, black` |
| [`0934342b`](https://github.com/NixOS/nixpkgs/commit/0934342ba2c3a62614f8f7f8fdb46943239994c2) | `python310Packages.flask-jwt-extended: 4.4.1 -> 4.4.2`                              |
| [`7d58f625`](https://github.com/NixOS/nixpkgs/commit/7d58f625e2bf0306255174aa0319f280b32f88b0) | `linux/hardened/patches/5.4: 5.4.200-hardened1 -> 5.4.201-hardened1`                |
| [`57d38001`](https://github.com/NixOS/nixpkgs/commit/57d38001ad6b0c64ee9c83d5d24ec1464fc343ce) | `linux/hardened/patches/5.18: 5.18.6-hardened1 -> 5.18.7-hardened1`                 |
| [`d7973cd5`](https://github.com/NixOS/nixpkgs/commit/d7973cd50258a26105c42111894d53192f5f4705) | `linux/hardened/patches/5.15: 5.15.49-hardened1 -> 5.15.50-hardened1`               |
| [`3cf33ad0`](https://github.com/NixOS/nixpkgs/commit/3cf33ad016f3aeba8aba13cf68228ada4798924b) | `linux/hardened/patches/5.10: 5.10.124-hardened1 -> 5.10.125-hardened1`             |
| [`14479c95`](https://github.com/NixOS/nixpkgs/commit/14479c95a203204f6b82d956ebb657ba7ef3ca28) | `linux/hardened/patches/4.19: 4.19.248-hardened1 -> 4.19.249-hardened1`             |
| [`299b49b5`](https://github.com/NixOS/nixpkgs/commit/299b49b53941cccf42aaf32e3bd2e1d75d71f847) | `linux/hardened/patches/4.14: 4.14.284-hardened1 -> 4.14.285-hardened1`             |
| [`dfc38c7b`](https://github.com/NixOS/nixpkgs/commit/dfc38c7baa9ed3d107921f444de6a76f1a3c5cbd) | `linux: 5.4.200 -> 5.4.201`                                                         |
| [`a13afa2d`](https://github.com/NixOS/nixpkgs/commit/a13afa2d90d98c3005032e5e7df9002b31134339) | `linux: 5.18.6 -> 5.18.7`                                                           |
| [`17996e10`](https://github.com/NixOS/nixpkgs/commit/17996e10f9cccb35fc16e86d8f9dd2c12fc78130) | `linux: 5.15.49 -> 5.15.50`                                                         |
| [`48f604ef`](https://github.com/NixOS/nixpkgs/commit/48f604ef690b2845ff20c0ac63134cfecff5724b) | `linux: 5.10.124 -> 5.10.126`                                                       |
| [`21c39a09`](https://github.com/NixOS/nixpkgs/commit/21c39a09698ce94f0be180027520c3b5169fb68d) | `linux: 4.9.319 -> 4.9.320`                                                         |
| [`34fe04da`](https://github.com/NixOS/nixpkgs/commit/34fe04da8e4ee12c72e7481fa3ac6506657f826b) | `linux: 4.19.248 -> 4.19.249`                                                       |
| [`2b50639f`](https://github.com/NixOS/nixpkgs/commit/2b50639f43b52134385da802d188f52846936223) | `linux: 4.14.284 -> 4.14.285`                                                       |