### PR TITLE
chore(flake/nixpkgs): `49a2bcc6` -> `e47f1d25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654012153,
-        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
+        "lastModified": 1656628719,
+        "narHash": "sha256-Ot9XWRWjWJ2bh2Rm7P9llCmBaQVSDIQJ+F1PMHE8XH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
+        "rev": "e47f1d2527f6109ea74940f01fcfe168a00bc5f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`e47f1d25`](https://github.com/NixOS/nixpkgs/commit/e47f1d2527f6109ea74940f01fcfe168a00bc5f7) | `communi: 3.5.0 -> 3.6.0`                                                        |
| [`b0feee64`](https://github.com/NixOS/nixpkgs/commit/b0feee646713c08da547723ef483f5de0ee75491) | `hypnotix: 2.7 -> 2.8`                                                           |
| [`76928386`](https://github.com/NixOS/nixpkgs/commit/76928386b0141dffc95b50a1b64df7ed25eeba5b) | `newsboat: 2.27 -> 2.28`                                                         |
| [`f84a03ad`](https://github.com/NixOS/nixpkgs/commit/f84a03ad38b5996c74a7632cbde2880c79a41583) | `warp: 0.2.0 -> 0.2.1`                                                           |
| [`14f3b5b7`](https://github.com/NixOS/nixpkgs/commit/14f3b5b7dac1d2ed8d51cdd2e893a7a0d33fbdd8) | `megapixels: 1.4.3 -> 1.5.0`                                                     |
| [`04fcf7fc`](https://github.com/NixOS/nixpkgs/commit/04fcf7fcded8cf8f261ec61c1f9065f188bad4e5) | `passExtensions.pass-import: support pykeepass 4.0.3`                            |
| [`1bf827d0`](https://github.com/NixOS/nixpkgs/commit/1bf827d026e8f4f31de1fb483f6d3b3df90a21c6) | `python310Packages.pykeepass: 4.0.2 -> 4.0.3`                                    |
| [`51b2b750`](https://github.com/NixOS/nixpkgs/commit/51b2b750524b3f99e3a9a96a6950956f5b0e98ed) | `python310Packages.pikepdf: 5.1.5 -> 5.1.5.post1`                                |
| [`eb94c5c5`](https://github.com/NixOS/nixpkgs/commit/eb94c5c57e08d41856d4ad9db496cb9213c16d94) | `python310Packages.traitsui: 7.3.1 -> 7.4.0`                                     |
| [`cdcded8d`](https://github.com/NixOS/nixpkgs/commit/cdcded8d8c09cd62f32fd6890a2b93ffec2372db) | `python310Packages.textdistance: 4.2.2 -> 4.3.0`                                 |
| [`4abac2ba`](https://github.com/NixOS/nixpkgs/commit/4abac2ba6c471eda9e2f490261c0c46fdac791a8) | `python310Packages.qiskit-optimization: 0.3.2 -> 0.4.0`                          |
| [`4dc5e4c9`](https://github.com/NixOS/nixpkgs/commit/4dc5e4c97e0748a5cb00ac42d628eadc45b04aa5) | `python310Packages.venstarcolortouch: 0.16 -> 0.17`                              |
| [`30ab1697`](https://github.com/NixOS/nixpkgs/commit/30ab1697a9c4f08cefb845f1eb2438154ac8d7d4) | `python310Packages.resampy: switch to pytestCheckHook`                           |
| [`e427ac59`](https://github.com/NixOS/nixpkgs/commit/e427ac5955f4b3abdc17636a80865b1b3fe720ae) | `ktunnel: init at 1.4.8`                                                         |
| [`a1ad66a4`](https://github.com/NixOS/nixpkgs/commit/a1ad66a4afa34b4517bd6adeb0812901271a5a58) | `vector: 0.22.2 -> 0.22.3`                                                       |
| [`08173c03`](https://github.com/NixOS/nixpkgs/commit/08173c03f052fed9c71d1b58ff7106ae19d4c6d8) | `python310Packages.resampy: 0.2.2 -> 0.3.0`                                      |
| [`e7d52cc2`](https://github.com/NixOS/nixpkgs/commit/e7d52cc26c5cbbfffa7dcedc7ab9b7ddff6bc234) | `scala-cli: 0.1.8 -> 0.1.9`                                                      |
| [`8771f95f`](https://github.com/NixOS/nixpkgs/commit/8771f95f71ffb6aecd67f5743467e0961844e0a9) | `python3Packages.trezor: 0.13.0 -> 0.13.2`                                       |
| [`323b6dfb`](https://github.com/NixOS/nixpkgs/commit/323b6dfb62806caa4e02cc5fb007917ebdd49a27) | `python3Packages.simple-rlp: init at 0.1.2`                                      |
| [`588439e1`](https://github.com/NixOS/nixpkgs/commit/588439e1311c41a5779877d4d8ef603410b79cd4) | `fetchurl: Add curlOptsList test`                                                |
| [`6724234f`](https://github.com/NixOS/nixpkgs/commit/6724234f2821eafed028c98501edb5a4bfdb9aa3) | `ocamlPackages.mirage-vnetif: 0.5.0 → 0.6.0`                                     |
| [`7e63d01a`](https://github.com/NixOS/nixpkgs/commit/7e63d01a23e9064ebfa5efd9b9393326bb208ad3) | `python310Packages.schwifty: 2022.6.2 -> 2022.6.3`                               |
| [`989565d6`](https://github.com/NixOS/nixpkgs/commit/989565d67661918799c6190a43db60590600dd01) | `cachix-agent: expose verbose option`                                            |
| [`ce910fca`](https://github.com/NixOS/nixpkgs/commit/ce910fca8841061e86bfbfd15f8976132c2bfd78) | `nixos/tests: add phlactery`                                                     |
| [`f5f338c8`](https://github.com/NixOS/nixpkgs/commit/f5f338c8468a84b624980c2fd2cf2fa32d14741b) | `nixos/phylactery: init`                                                         |
| [`7727befa`](https://github.com/NixOS/nixpkgs/commit/7727befa4d5968d41cb7778d0abe0f5accdae77d) | `nrfconnect: init at 3.11.1`                                                     |
| [`78f355a1`](https://github.com/NixOS/nixpkgs/commit/78f355a11e163912ccab31079514aa3b55946599) | `davmail: 5.5.1 -> 6.0.1`                                                        |
| [`13165465`](https://github.com/NixOS/nixpkgs/commit/1316546506ad0b591a0e782172abdbc12af349a5) | `neovim: 0.7.0 -> 0.7.2`                                                         |
| [`9e106c15`](https://github.com/NixOS/nixpkgs/commit/9e106c15a4be9d1ddd057ddf9c34851ffd76cf52) | `wesnoth: 1.16.1 -> 1.16.3`                                                      |
| [`36634aa9`](https://github.com/NixOS/nixpkgs/commit/36634aa9d1ce6db3b351ea2c9c96f40fab76d452) | `python310Packages.motionblinds: 0.6.8 -> 0.6.10`                                |
| [`e7f35074`](https://github.com/NixOS/nixpkgs/commit/e7f35074a20441009cc4b2301107e76a82b6c91a) | `python310Packages.hahomematic: 1.9.0 -> 1.9.1`                                  |
| [`6c8432f3`](https://github.com/NixOS/nixpkgs/commit/6c8432f34616100e7cdd60dc9eac2b86f26c6424) | `checkov: 2.1.16 -> 2.1.20`                                                      |
| [`783e2ef4`](https://github.com/NixOS/nixpkgs/commit/783e2ef46e9ec6639d914aa3f9ecd5cc6b812868) | `Revert "nix-prefetch-git: Fix inconsistency with fetchgit regarding deepClone"` |
| [`41122605`](https://github.com/NixOS/nixpkgs/commit/411226059152365c13a94da80e70ef43178b7f5c) | `python310Packages.twilio: 7.9.3 -> 7.10.0`                                      |
| [`d6b64a69`](https://github.com/NixOS/nixpkgs/commit/d6b64a69851d430b128ecbeaea714f5de283dc64) | `python310Packages.temescal: 0.3 -> 0.5`                                         |
| [`b44f6df4`](https://github.com/NixOS/nixpkgs/commit/b44f6df49725d9d968dc14e97cfcb0d21f8368d3) | `nix-update: 0.5.1 -> 0.6.0`                                                     |
| [`b091bae6`](https://github.com/NixOS/nixpkgs/commit/b091bae60a0fe244d38bb20f84fc0b86e6a29aa8) | `schleuder-cli: allow running on aarch64-linux`                                  |
| [`81fe5f1b`](https://github.com/NixOS/nixpkgs/commit/81fe5f1b2f01e12874974b654bf51cdc01d32588) | `schleuder: allow running on aarch64-linux`                                      |
| [`51267049`](https://github.com/NixOS/nixpkgs/commit/512670498f288c98279bfae0910a2811b9dd51e2) | `phylactery: init at 0.1.1`                                                      |
| [`a1aed2a7`](https://github.com/NixOS/nixpkgs/commit/a1aed2a716ff3471f91f0ba57f551335202df98b) | `builders/writeHaskell: build with threaded GHC runtime`                         |
| [`7f3cdfd2`](https://github.com/NixOS/nixpkgs/commit/7f3cdfd2ba5a05a2d413c2cd9c421a4b0a28ac94) | `dtc: fix static building`                                                       |
| [`2c7fcab1`](https://github.com/NixOS/nixpkgs/commit/2c7fcab1ce3ff2d024713498475e18d260e8f887) | `lagrange: 1.13.6 -> 1.13.7`                                                     |
| [`d12a3655`](https://github.com/NixOS/nixpkgs/commit/d12a36559b57c01d73066eb7960498a55e2d08dd) | `ipget: 0.8.1->0.9.1`                                                            |
| [`873d7f1f`](https://github.com/NixOS/nixpkgs/commit/873d7f1f18e4a3e6689a210bc259ad863e387d3b) | `addlicense: 1.0.0 -> unstable-2021-04-22`                                       |
| [`3e2582c1`](https://github.com/NixOS/nixpkgs/commit/3e2582c14b53062bf83ef3dba8ac7374f4868cca) | `fluxcd: 0.31.2 -> 0.31.3`                                                       |
| [`ba1db2b2`](https://github.com/NixOS/nixpkgs/commit/ba1db2b2055358d42ea77f74c0958e91109c8fec) | `dsq: 0.20.2 -> 0.21.0`                                                          |
| [`f7d9436e`](https://github.com/NixOS/nixpkgs/commit/f7d9436ead245b0a99c94155c8d20840ecfd9c9e) | `clojure-lsp: 2022.06.22-14.09.50 -> 2022.06.29-19.32.13`                        |
| [`41d9b090`](https://github.com/NixOS/nixpkgs/commit/41d9b0908c4068f17a2d528e2e920d2146aa4925) | `python310Packages.nextcord: 2.0.0b3 -> 2.0.0`                                   |
| [`d3248619`](https://github.com/NixOS/nixpkgs/commit/d3248619647234b5dc74a6921bcdf6dd8323eb22) | `python310Packages.python-telegram-bot: 13.12 -> 13.13 (#179588)`                |
| [`ba533129`](https://github.com/NixOS/nixpkgs/commit/ba533129002f7fc5974df424679c4a3a8d4d3520) | `python310Packages.sanic-testing: 22.3.0 -> 22.3.1`                              |
| [`ccef4ede`](https://github.com/NixOS/nixpkgs/commit/ccef4edeaf5175edb5c6a9fa3f81c7d833fb69d5) | `python310Packages.sagemaker: 2.96.0 -> 2.97.0`                                  |
| [`c7b135ac`](https://github.com/NixOS/nixpkgs/commit/c7b135ac8ebf53e4e2c94cc9340f6199801d42e4) | `cachix-agent: properly handle not restarting the service`                       |
| [`af384e15`](https://github.com/NixOS/nixpkgs/commit/af384e15ae4a97df75510fefea547e8664f3a488) | `runitor: drop unused input`                                                     |
| [`97d398eb`](https://github.com/NixOS/nixpkgs/commit/97d398eb2a768fca806d56a978aa09573e3bf40b) | `terraform: 1.2.3 -> 1.2.4`                                                      |
| [`2ab459bd`](https://github.com/NixOS/nixpkgs/commit/2ab459bd9a7bec7c27a93ec23279b1bd660d3418) | `monoid: 2018-06-03 -> 2020-10-26`                                               |
| [`1419d299`](https://github.com/NixOS/nixpkgs/commit/1419d299069dfcdc1c34871128456b774b5db5b8) | `opencpn: unalias epoxy`                                                         |
| [`d27e6f2d`](https://github.com/NixOS/nixpkgs/commit/d27e6f2d052214b21cbbbe2efc6ab46615ae3ee5) | `haskellPackages: Unalias RunCommandNoCCLocal`                                   |
| [`021cf726`](https://github.com/NixOS/nixpkgs/commit/021cf726fcd54fa47f5c5b78f8b897ddfb878b73) | `python310Packages.cartopy: 0.20.2 -> 0.20.3`                                    |
| [`f804d136`](https://github.com/NixOS/nixpkgs/commit/f804d136074bb3ad43c8d3d2f83349044769603c) | `python310Packages.json-schema-for-humans: 0.41.1 -> 0.41.3`                     |
| [`85afe973`](https://github.com/NixOS/nixpkgs/commit/85afe9737c7182185cfdaaeedefb2d10a3641aa6) | `sov: fix default config location (#178882)`                                     |
| [`f14b6f55`](https://github.com/NixOS/nixpkgs/commit/f14b6f553a7721b963cf10048adf35d08d5d0253) | `javacc: fix meta.maintainers`                                                   |
| [`eda6d6e0`](https://github.com/NixOS/nixpkgs/commit/eda6d6e075d4dc71638265d39f6c0157d76aa7bd) | `libsForQt5.drumstick: 2.5.1 -> 2.6.1`                                           |
| [`b0e82c68`](https://github.com/NixOS/nixpkgs/commit/b0e82c6809e51123a2e152cc6353b317210ea88b) | `xfsdump: fix build against xfsprogs 5.18.0`                                     |
| [`028af6dd`](https://github.com/NixOS/nixpkgs/commit/028af6dd4a5b08333fead4d20023aa181d8a1bb4) | `python310Packages.karton-mwdb-reporter: unstable-2022-02-22 -> 1.1.0`           |
| [`dd52d403`](https://github.com/NixOS/nixpkgs/commit/dd52d403671974d1a89e1b723a593c91528e2995) | `deadbeefPlugins.playlist-manager: init at unstable-2021-05-02`                  |
| [`5bec894d`](https://github.com/NixOS/nixpkgs/commit/5bec894dc12d68a95f764009c7187c057601e58e) | `deadbeefPlugins.mpris2: 1.12 -> 1.14`                                           |
| [`b0f64184`](https://github.com/NixOS/nixpkgs/commit/b0f641840bfb2ab04c8d15e1a68742b516594776) | `deadbeef: 1.8.4 -> 1.9.1`                                                       |
| [`ad892591`](https://github.com/NixOS/nixpkgs/commit/ad892591a583c30df6c99331f8c42b5424df4e56) | `swift-corelibs-libdispatch: init at swift-5.5-RELEASE`                          |
| [`7b410b13`](https://github.com/NixOS/nixpkgs/commit/7b410b13eeff35506bf581997d37731572e0fbda) | `ocamlPackages.ke: 0.4 → 0.6`                                                    |
| [`411074a6`](https://github.com/NixOS/nixpkgs/commit/411074a6ef78e464609f0fcd591a15aa972711a1) | `haxePackages.heaps: init at 1.9.1`                                              |
| [`b1987d77`](https://github.com/NixOS/nixpkgs/commit/b1987d775203691b820f8c4bc793fb6dc0111f24) | `haxePackages.hlsdl: init at 1.10.0`                                             |
| [`45da69f6`](https://github.com/NixOS/nixpkgs/commit/45da69f65eea3a7e097effb35f2318a2c98d23ac) | `haxePackages.hlopenal: init at 1.5.0`                                           |
| [`cd4eeacc`](https://github.com/NixOS/nixpkgs/commit/cd4eeacc7e78552d8d48674df42db18190073087) | `haxePackages.format: init at 3.5.0`                                             |
| [`9d7932e3`](https://github.com/NixOS/nixpkgs/commit/9d7932e349942db74ec2c3a7030085c77d7a3716) | `fastly: init at 3.1.0`                                                          |
| [`12f818e3`](https://github.com/NixOS/nixpkgs/commit/12f818e3045279745a4d52da9aa293398e221a42) | `erofs-utils: 1.4 -> 1.5`                                                        |
| [`bb6885f3`](https://github.com/NixOS/nixpkgs/commit/bb6885f3f386c9a674c4603b73da07986755800d) | `gnunet: 0.16.3 -> 0.17.1`                                                       |
| [`aaa1cf94`](https://github.com/NixOS/nixpkgs/commit/aaa1cf94f9d83a8c75bcea76ef62b6fe8f1acf85) | `scribus: 1.5.7 -> 1.5.8`                                                        |
| [`08ddd8a5`](https://github.com/NixOS/nixpkgs/commit/08ddd8a5fcbd4f0cc872304035e54a21fbcbb321) | `nixos-generate-config: detect parallels virtualization`                         |
| [`5f63ac02`](https://github.com/NixOS/nixpkgs/commit/5f63ac02e36ef6528814d9aa4fb1dfee2c538c96) | `pkgsMusl.libical: fix build by disabling tests`                                 |
| [`64f50578`](https://github.com/NixOS/nixpkgs/commit/64f5057853fea5d7b30b69a210364d516ebf512c) | `traefik: 2.7.1 -> 2.7.2`                                                        |
| [`4e63de22`](https://github.com/NixOS/nixpkgs/commit/4e63de22e2fd2c3409a6d3bb3a0d0e4688d6c16a) | `python310Packages.boxx: 0.10.1 -> 0.10.4`                                       |
| [`546489d0`](https://github.com/NixOS/nixpkgs/commit/546489d01756f83bf085396a9ef728accaa4fa2b) | `maintainers: add snapdgn`                                                       |
| [`bdf9ab61`](https://github.com/NixOS/nixpkgs/commit/bdf9ab616a53e0e5ea2c3dc9d388a5c7a68d0478) | `n8n: 0.182.1 → 0.184.0`                                                         |
| [`54aa5269`](https://github.com/NixOS/nixpkgs/commit/54aa52698d1025e1c3456d02c5e8e0df44343efc) | `python310Packages.pygtkspellcheck: 4.0.6 -> 5.0.0`                              |
| [`f5dfb9a0`](https://github.com/NixOS/nixpkgs/commit/f5dfb9a0d47fc3699dc5b096d5aa9f62e0163c58) | `sile: 0.13.1 → 0.13.2`                                                          |
| [`0a6483ce`](https://github.com/NixOS/nixpkgs/commit/0a6483ce41e2cb8a98e2faba6ff4c90da293c077) | `grafana: 9.0.1 -> 9.0.2`                                                        |
| [`c8941fc6`](https://github.com/NixOS/nixpkgs/commit/c8941fc6c858e8f310c758e66f7a62d86ccb2fa7) | `zotero: 6.0.8 -> 6.0.9`                                                         |
| [`e6b696e3`](https://github.com/NixOS/nixpkgs/commit/e6b696e3e2e34fd001ed3070a5b7642c142bfe15) | `python310Packages.peaqevcore: 2.0.2 -> 2.1.1`                                   |
| [`02cc4494`](https://github.com/NixOS/nixpkgs/commit/02cc44949cbac7a4500a0e2e20f91c740d7cfe72) | `python310Packages.homeconnect: 0.7.0 -> 0.7.1`                                  |
| [`b4fe5adb`](https://github.com/NixOS/nixpkgs/commit/b4fe5adbddf1a2307177e14e9335283822abf0a4) | `python310Packages.simplisafe-python: 2022.06.0 -> 2022.06.1`                    |
| [`008ccf30`](https://github.com/NixOS/nixpkgs/commit/008ccf301f3dd2bf48fd64395f645eef448989fd) | `python310Packages.xknx: 0.21.4 -> 0.21.5`                                       |
| [`3e3ee91e`](https://github.com/NixOS/nixpkgs/commit/3e3ee91e933dd94ab2f70aa1f9bd6a76f68ec965) | `python310Packages.pynetgear: 0.10.5 -> 0.10.6`                                  |
| [`fb3101b2`](https://github.com/NixOS/nixpkgs/commit/fb3101b204c7639bea7aa763d8e670bafb00b8bf) | `python310Packages.weconnect-mqtt: 0.35.0 -> 0.37.2`                             |
| [`fd7dff9e`](https://github.com/NixOS/nixpkgs/commit/fd7dff9ea3c9b6b99d141149bf75c08dde7d7863) | `python310Packages.weconnect: 0.41.0 -> 0.44.2`                                  |
| [`e0b0dcb9`](https://github.com/NixOS/nixpkgs/commit/e0b0dcb982c677b524182fdcc34f727c360beee1) | `exploitdb: 2022-06-15 -> 2022-06-28`                                            |
| [`78dd1e59`](https://github.com/NixOS/nixpkgs/commit/78dd1e59029f2c4614b6e1dad25b10a233af8afa) | `python310Packages.bc-python-hcl2: 0.3.43 -> 0.3.44`                             |
| [`85856bae`](https://github.com/NixOS/nixpkgs/commit/85856baed353fece78a21767dd2da33afbbb063b) | `python310Packages.angr: 9.2.7 -> 9.2.8`                                         |
| [`18006322`](https://github.com/NixOS/nixpkgs/commit/1800632205d34f4b535a234cb5844bc257810e50) | `python310Packages.cle: 9.2.7 -> 9.2.8`                                          |
| [`79076ad5`](https://github.com/NixOS/nixpkgs/commit/79076ad5ba57adfcc53f7395a4299710037884c6) | `python310Packages.claripy: 9.2.7 -> 9.2.8`                                      |
| [`ac98e19d`](https://github.com/NixOS/nixpkgs/commit/ac98e19d1fb862a719f046d44800eca8c20b8a88) | `python310Packages.pyvex: 9.2.7 -> 9.2.8`                                        |
| [`3529b5d6`](https://github.com/NixOS/nixpkgs/commit/3529b5d67d17c8510a4bfdff4a752f0273205489) | `python310Packages.ailment: 9.2.7 -> 9.2.8`                                      |
| [`e8ac7b9c`](https://github.com/NixOS/nixpkgs/commit/e8ac7b9cc6d77519828583f9248a831c69191fb7) | `python310Packages.archinfo: 9.2.7 -> 9.2.8`                                     |
| [`6a0effc6`](https://github.com/NixOS/nixpkgs/commit/6a0effc6f04fada686c8047e5567ab1a5b0d0870) | `python310Packages.rzpipe: 0.1.2 -> 0.4.0`                                       |
| [`67512d03`](https://github.com/NixOS/nixpkgs/commit/67512d036de4df47e72bb6e9fa91520dfb6c5ce2) | `checkov: 2.1.10 -> 2.1.16`                                                      |
| [`96fb180e`](https://github.com/NixOS/nixpkgs/commit/96fb180e8218ed7f5c96a43c0646c012de759e62) | `python310Packages.zha-quirks: 0.0.75 -> 0.0.77`                                 |
| [`b607d51a`](https://github.com/NixOS/nixpkgs/commit/b607d51a88efe300aa199f4ce382c2ab24693347) | `changelogger: init at 0.5.2`                                                    |
| [`910a91e0`](https://github.com/NixOS/nixpkgs/commit/910a91e05c89d6aeecb5b947dcfefda4c9e4e617) | `yt-dlp: 2022.6.22.1 -> 2022.6.29`                                               |
| [`e1eb35fb`](https://github.com/NixOS/nixpkgs/commit/e1eb35fb793739b4a3468efcac23fe67c45eb323) | `python310Packages.dremel3dpy: 2.0.1 -> 2.1.1`                                   |
| [`bed0a7d1`](https://github.com/NixOS/nixpkgs/commit/bed0a7d1163cc2edd559eb559aab2aed28351917) | `gallery-dl: 1.22.1 -> 1.22.3`                                                   |
| [`c070fba7`](https://github.com/NixOS/nixpkgs/commit/c070fba77fb9f03e3fa1015fb6502120a4dc5eea) | `pdftk: use regular jre`                                                         |
| [`2338fffa`](https://github.com/NixOS/nixpkgs/commit/2338fffa0f9478cb19893c8262618d3df59e5bd1) | `gvm-tools: 22.6.0 -> 22.6.1`                                                    |
| [`95a7f024`](https://github.com/NixOS/nixpkgs/commit/95a7f0244aa8b935d84e4a3b7ee8090ce9c00caa) | `datadog-agent: make systemd optional`                                           |
| [`466b1471`](https://github.com/NixOS/nixpkgs/commit/466b14712f467c962c4c2d89c9c96fc0b9ca0e3c) | `maintainers: remove bjg`                                                        |
| [`d3991bc5`](https://github.com/NixOS/nixpkgs/commit/d3991bc5be2ff874a799c3f4b436b82ead09dab1) | `maintainers: remove lyt`                                                        |
| [`17da0007`](https://github.com/NixOS/nixpkgs/commit/17da0007412f624ada37b772586de8592acbc09b) | `maintainers: remove zef`                                                        |
| [`1bce27ea`](https://github.com/NixOS/nixpkgs/commit/1bce27ea1a12303862d04e87c5c039d4e40cd6e8) | `maintainers: remove Esteth`                                                     |
| [`d26d95d3`](https://github.com/NixOS/nixpkgs/commit/d26d95d39a995798d1cf20c71b7af1a25e0a8b66) | `maintainers: remove miltador`                                                   |
| [`0c35b851`](https://github.com/NixOS/nixpkgs/commit/0c35b851e4988d947d87747feed2c0f7415d2fe5) | `maintainers: remove kkallio`                                                    |
| [`143efb53`](https://github.com/NixOS/nixpkgs/commit/143efb53d6adb6c929338230a71ebdd65f392daf) | `maintainers: remove m3tti`                                                      |
| [`fd75d8c2`](https://github.com/NixOS/nixpkgs/commit/fd75d8c2d398721d1c75df17e3b1d33d315b88ea) | `maintainers: remove chattered`                                                  |
| [`a111cc0c`](https://github.com/NixOS/nixpkgs/commit/a111cc0c2c82852c8aee1bd02de0cc58dae443a0) | `maintainers: remove lrworth`                                                    |
| [`fa32663f`](https://github.com/NixOS/nixpkgs/commit/fa32663f502725015bbb593fa0ebf25bfc5043c8) | `maintainers: remove fuzzy-id`                                                   |
| [`883e38ae`](https://github.com/NixOS/nixpkgs/commit/883e38ae9740b60e554376a8b026fd29e9da4a03) | `maintainers: remove okasu`                                                      |
| [`95d1c563`](https://github.com/NixOS/nixpkgs/commit/95d1c563858fbdcef3b5b56db41a5891dde7e42a) | `maintainers: remove wedens`                                                     |
| [`e23c5a94`](https://github.com/NixOS/nixpkgs/commit/e23c5a9471fce11f27cdbaf4233992c644468df4) | `maintainers: remove funfunctor`                                                 |
| [`9c583f06`](https://github.com/NixOS/nixpkgs/commit/9c583f06af42e39e29ceb8bfbf405d013c79684d) | `maintainers: remove schristo`                                                   |
| [`b67a9bff`](https://github.com/NixOS/nixpkgs/commit/b67a9bffcc8e740217b1984287f49070d7bce499) | `maintainers: remove hinton`                                                     |
| [`3f5b809a`](https://github.com/NixOS/nixpkgs/commit/3f5b809a5fc735cfc3a35752ca6fd67240314d12) | `maintainers: remove sjourdois`                                                  |
| [`d62c3bb2`](https://github.com/NixOS/nixpkgs/commit/d62c3bb22ea458fee4aa0471587bc0b39570e1b1) | `maintainers: remove ravloony`                                                   |
| [`89fbc3fe`](https://github.com/NixOS/nixpkgs/commit/89fbc3fea9844d318410128c463187df5c2f61c0) | `maintainers: remove balajisivaraman`                                            |
| [`45ec5898`](https://github.com/NixOS/nixpkgs/commit/45ec5898cbe01554bc918b6411a85098c2017f78) | `maintainers: remove tstrobel`                                                   |
| [`a8517f95`](https://github.com/NixOS/nixpkgs/commit/a8517f95b85579d7a6c29d2d4d726f1078c68082) | `maintainers: remove joelteon`                                                   |
| [`330f745f`](https://github.com/NixOS/nixpkgs/commit/330f745f6f133f86f1f2ffd6d6c06d115fdf49e1) | `maintainers: remove skrzyp`                                                     |
| [`a2e2f912`](https://github.com/NixOS/nixpkgs/commit/a2e2f9128d11246e690aee4a2e2b2045ac1d1204) | `maintainers: remove markWot`                                                    |
| [`0aac41a5`](https://github.com/NixOS/nixpkgs/commit/0aac41a5d98ea1410f2039d6c8eabc70a8904e2a) | `maintainers: remove winden`                                                     |
| [`4272b643`](https://github.com/NixOS/nixpkgs/commit/4272b6439b874679fcc58fc3af9c58b9251eadc1) | `maintainers: remove willtim`                                                    |
| [`e59cb525`](https://github.com/NixOS/nixpkgs/commit/e59cb525caf1aa7ebb712615d28f93d1f02e77e9) | `maintainers: remove nfjinjing`                                                  |
| [`e966ab39`](https://github.com/NixOS/nixpkgs/commit/e966ab3965a656efdd40b6ae0d8cec6183972edc) | `maintainers: remove all`                                                        |
| [`19e6ace1`](https://github.com/NixOS/nixpkgs/commit/19e6ace19fa5aaf7b854306dd8742f15c4d5c236) | `maintainers: remove epitrochoid`                                                |