### PR TITLE
chore(flake/fenix): `47f9bff2` -> `82b14d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1656570463,
-        "narHash": "sha256-jDoY23BRZ/lE+yB5as7qoevLs0T1nfBJMYJzIFIy3sE=",
+        "lastModified": 1661929115,
+        "narHash": "sha256-XnCL0aLeQIbh0Ua51m8lF4sQFGn9tc+8VZLOQ9UEDAA=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "47f9bff2d9ea48977b1c9565844e1f3be6deee15",
+        "rev": "82b14d02053f49d70c834f8e5ef6f07fe804d7eb",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1656443930,
-        "narHash": "sha256-IcUo9c6qaH9h2XSpbwooH/OsxS3n13OVMPT9LWT7TFU=",
+        "lastModified": 1661866297,
+        "narHash": "sha256-Q0aniSF4Skm7yYE1Z2Jikn0C7Hpjbk94eha2Y7GWjPk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "b0102bd469a0d9d5008ce3b5ae0fa1f13e8d18d0",
+        "rev": "989b09d20cafc2b1eb9198e25701b9e2234d8ba0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`82b14d02`](https://github.com/nix-community/fenix/commit/82b14d02053f49d70c834f8e5ef6f07fe804d7eb) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b8d50e5b`](https://github.com/nix-community/fenix/commit/b8d50e5b6662ba618fe7a28df478044327294aaa) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b5f22612`](https://github.com/nix-community/fenix/commit/b5f2261237c6418e36c2994fd5f83df42ab38d47) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`ed52331c`](https://github.com/nix-community/fenix/commit/ed52331c095a99250cc36e6668f90d55108858b4) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`962dafad`](https://github.com/nix-community/fenix/commit/962dafad624929bf713b6e9da38aeb8818da219e) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b5cae8a0`](https://github.com/nix-community/fenix/commit/b5cae8a0efb6b02c1874f4d278c87291804199af) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`ff99d3ce`](https://github.com/nix-community/fenix/commit/ff99d3ce52f35522a62a18d5d650d0ce8508c345) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`3268d42e`](https://github.com/nix-community/fenix/commit/3268d42e277ff23df0233c96a34aac0b7b3eb206) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`1d19a144`](https://github.com/nix-community/fenix/commit/1d19a144c31605080a4a2c17fa236dc7e9856042) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b30862cd`](https://github.com/nix-community/fenix/commit/b30862cd69d405849e4b3e79972da551bf5620bb) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`9898526c`](https://github.com/nix-community/fenix/commit/9898526c29ac731c42b3c765fd10c64beac777ae) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`961be8c3`](https://github.com/nix-community/fenix/commit/961be8c35ae8e0a70e6eef211c70644f3a8e3ec3) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`dca822b6`](https://github.com/nix-community/fenix/commit/dca822b67ddf0af52f9b63feaeefc1668c8635c0) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`aa24b7ea`](https://github.com/nix-community/fenix/commit/aa24b7eacd6f60c92fc60aaa214b597c930ac7af) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`45e0e097`](https://github.com/nix-community/fenix/commit/45e0e09763325668109ee1f23622aec6fd01e5a8) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`41731c1a`](https://github.com/nix-community/fenix/commit/41731c1a7ba1441c7544e8a0387aaf58e48f26b8) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`4ef74f9d`](https://github.com/nix-community/fenix/commit/4ef74f9d2d898d9cade26c30ce34c57420a9cb94) | `Correct minor typo in README`                                      |
| [`2d905869`](https://github.com/nix-community/fenix/commit/2d905869b301d899e56d3e9ed668521c47ed05e5) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`54253fb2`](https://github.com/nix-community/fenix/commit/54253fb23a5871466ada5c0334b6e39a0bcdb4db) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`ccd2c48e`](https://github.com/nix-community/fenix/commit/ccd2c48e886d325ff0130781db69394c6906a245) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`8de16aee`](https://github.com/nix-community/fenix/commit/8de16aeedcaf13825b949f7ef5c4574ec14473e1) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`14d9f22c`](https://github.com/nix-community/fenix/commit/14d9f22c673b128f3e2339157a6d8eaff7dbc5ec) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b952fad3`](https://github.com/nix-community/fenix/commit/b952fad30060fb7a98613b30e3b4df0d160e492c) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`5154b100`](https://github.com/nix-community/fenix/commit/5154b100dd33149d0a53e46e69e15d6bc7ca0f8d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`cfcc0eb4`](https://github.com/nix-community/fenix/commit/cfcc0eb48484890882e83372db1d5fdc6a0e0f67) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b94c35e0`](https://github.com/nix-community/fenix/commit/b94c35e0d375540691411639458c21dd508ef3ed) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`5878e501`](https://github.com/nix-community/fenix/commit/5878e50188643a549a9f451d8724ae6d16147a74) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`282c9f7a`](https://github.com/nix-community/fenix/commit/282c9f7ae5ed3078424dc6ba85422a533b5ca7aa) | `update: remove list of std targets`                                |
| [`7d319ba8`](https://github.com/nix-community/fenix/commit/7d319ba81a1405267e6c8cbbde975230713ea1d3) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`e2905b33`](https://github.com/nix-community/fenix/commit/e2905b33123d00ef617b4369a3db2abb7be450d3) | `nixpkgs-fmt`                                                       |
| [`0d2c5d63`](https://github.com/nix-community/fenix/commit/0d2c5d63cdfcc9a890a7d9d2a2e6193a3e84fcca) | `ci: build different versions with a matrix to reduce space needed` |
| [`2913319b`](https://github.com/nix-community/fenix/commit/2913319b72513cf696b92a521904203a18a70e53) | `alias rust-analyzer-preview component to rust-analyzer`            |
| [`e7be70f0`](https://github.com/nix-community/fenix/commit/e7be70f0e0c7264417a322f2938702c93d7edc93) | `fix: patch executables in libexec directory, fixes #74`            |
| [`04139cda`](https://github.com/nix-community/fenix/commit/04139cdad3f65929f372f8c2707c1ed812e7243f) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`1257580d`](https://github.com/nix-community/fenix/commit/1257580dcc711204cfdee4994255b2c3ae9a9a0b) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`862c23b3`](https://github.com/nix-community/fenix/commit/862c23b3607d13166ef7493c7dc0995b1771a583) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`75a63f08`](https://github.com/nix-community/fenix/commit/75a63f0868d8362aaa0ae2f9d5e77a65780fdd58) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`e4787a9b`](https://github.com/nix-community/fenix/commit/e4787a9b299117979bd04d396466c9c7cb4ac568) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`4fc95f73`](https://github.com/nix-community/fenix/commit/4fc95f732d7a8c97d8307854532e29a96238779c) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`f14a4bc8`](https://github.com/nix-community/fenix/commit/f14a4bc863d510e86553dcd5a599a962ebfff2f6) | `test: fix miri`                                                    |
| [`5478dbbe`](https://github.com/nix-community/fenix/commit/5478dbbee3a6f15c57dd01e99bbeff6544ce6998) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`f44d44e0`](https://github.com/nix-community/fenix/commit/f44d44e0e73ca2b489f76691902505ff3200e23c) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`96e9afe0`](https://github.com/nix-community/fenix/commit/96e9afe035ab31a6aa1a6deeb7a3cee2d8d7591d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`9e6e8481`](https://github.com/nix-community/fenix/commit/9e6e848195e1b72dc078206c3fb3669f2a122840) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`80981ee7`](https://github.com/nix-community/fenix/commit/80981ee71b32ce0747d22b1fd2dcd895219f5c1d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`a844a251`](https://github.com/nix-community/fenix/commit/a844a251dcd8aac45d47a81adae6117ff4f57b8d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`441b2aee`](https://github.com/nix-community/fenix/commit/441b2aeebfb0582ce300becebcf8ffb58300d9ec) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`353d5ac5`](https://github.com/nix-community/fenix/commit/353d5ac5d0e3e8c26fe7c6744afdb1929496b1df) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`bfd44cd2`](https://github.com/nix-community/fenix/commit/bfd44cd280ca8dc88415c5183f93a4e01cd1769d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`2263df04`](https://github.com/nix-community/fenix/commit/2263df04334e270aa7c2f967a88db61dd7cbfebc) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`69069698`](https://github.com/nix-community/fenix/commit/69069698c3aa14fc211c66c6635c1e34f4d6b441) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`85198435`](https://github.com/nix-community/fenix/commit/851984354b264c0cd9690957418cdeb0352dd779) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`7307f8f6`](https://github.com/nix-community/fenix/commit/7307f8f619cb3d91c4e8bdbfe7bef93f1e0097b8) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`6d837959`](https://github.com/nix-community/fenix/commit/6d837959635996aa3751ebc83f666d71144e459b) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`4ee90504`](https://github.com/nix-community/fenix/commit/4ee90504942122e544639926d689ecad41aebc95) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`ddd63d2b`](https://github.com/nix-community/fenix/commit/ddd63d2b8546a84bdcb27a9779e4f4ae0eec86e6) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`fd120f5d`](https://github.com/nix-community/fenix/commit/fd120f5d166057326c50c70b13531c2678076fa3) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`b814c83d`](https://github.com/nix-community/fenix/commit/b814c83d9e6aa5a28d0cf356ecfdafb2505ad37d) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`27dc96fb`](https://github.com/nix-community/fenix/commit/27dc96fb34c58a03475cddf4aaccef2e2078091b) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`a73d841d`](https://github.com/nix-community/fenix/commit/a73d841dbc39cdd881ae2ee7cb3991e357f9f9cc) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`d223a6c3`](https://github.com/nix-community/fenix/commit/d223a6c360d0873488b70df0a9d27e0f6487b8fe) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`60a53fa4`](https://github.com/nix-community/fenix/commit/60a53fa494e3646d2b7be218383d703aa8ece505) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`c5933255`](https://github.com/nix-community/fenix/commit/c5933255cadd599e9d1b4b98d801c12a923ff9d8) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`81c7b117`](https://github.com/nix-community/fenix/commit/81c7b1174ce69383258a27925bf0218dfc199356) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`7958c5e9`](https://github.com/nix-community/fenix/commit/7958c5e906a20f8d3308928cc184592cc413ccbe) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`f16a191a`](https://github.com/nix-community/fenix/commit/f16a191abcce70fd532805e7727caf64efa35678) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`e9b9b68f`](https://github.com/nix-community/fenix/commit/e9b9b68faefba3c25e9f4af477ccb815dc43c3d0) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`0ce83f7f`](https://github.com/nix-community/fenix/commit/0ce83f7f5b58a91c09fbc8e21c77ae5f3d680f09) | `update: rust toolchains, rust analyzer, flake.lock`                |
| [`e172d625`](https://github.com/nix-community/fenix/commit/e172d625f705ca4013f93d3fe061d3ecf1fc3a34) | `update: rust toolchains, rust analyzer, flake.lock`                |