### PR TITLE
chore(flake/flake-utils): `bee6a725` -> `c0e246b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c0e246b9`](https://github.com/numtide/flake-utils/commit/c0e246b9b83f637f4681389ecabcb2681b4f3af0) | `Update each-system template to use new flake output system (#76)` |
| [`7e2a3b3d`](https://github.com/numtide/flake-utils/commit/7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249) | `check-utils: use the same success derivation (#75)`               |