### PR TITLE
chore(flake/nixpkgs): `e47f1d25` -> `034175e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656628719,
-        "narHash": "sha256-Ot9XWRWjWJ2bh2Rm7P9llCmBaQVSDIQJ+F1PMHE8XH0=",
+        "lastModified": 1661984032,
+        "narHash": "sha256-IG9bSw8FLe8Ztms+lOb/Vn2bIqxwj6/a9T1xU5Wc8Y0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e47f1d2527f6109ea74940f01fcfe168a00bc5f7",
+        "rev": "034175e4bea4e4b735d35fd06e04213f0777d4ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`aba6cd17`](https://github.com/NixOS/nixpkgs/commit/aba6cd17c4785a82e6261cc00316cf97862a1ed2) | `python3Packages.torchvision: 1.13.0 -> 1.13.1`                                                         |
| [`5863492c`](https://github.com/NixOS/nixpkgs/commit/5863492c519eeea7f4caabddcefc2617a873a931) | `python3Packages.torchvision-bin: 1.12.0 -> 1.13.1`                                                     |
| [`8d3b89d0`](https://github.com/NixOS/nixpkgs/commit/8d3b89d030e6a3d5df80c8f61a8f72f1ba26caa1) | `python3Packages.torchaudio: 0.11.0 -> 0.12.1`                                                          |
| [`4b379580`](https://github.com/NixOS/nixpkgs/commit/4b37958011a18e69ba3987cfdca8815258a52172) | `python3Packages.torch-bin: 1.11.0 -> 1.12.1`                                                           |
| [`9b183572`](https://github.com/NixOS/nixpkgs/commit/9b183572a7789cd3b271af38ca1ca7245801e9af) | `python3Packages.torch: 1.11.0 -> 1.12.1`                                                               |
| [`ac455609`](https://github.com/NixOS/nixpkgs/commit/ac455609648554cf2fb40d9d1ce030202b0921b7) | `delta: 0.13.0 -> 0.14.0`                                                                               |
| [`9a64a6d1`](https://github.com/NixOS/nixpkgs/commit/9a64a6d1ef03e0339e82702856b241d450f6630e) | `ocamlPackages.plotkicadsch: init at 0.9`                                                               |
| [`2b2e5df4`](https://github.com/NixOS/nixpkgs/commit/2b2e5df47812fe5d2fc59b260bf422a07c3bf62a) | `ocamlPackages.git-unix: Add git to propagatedBuildInputs`                                              |
| [`12756f54`](https://github.com/NixOS/nixpkgs/commit/12756f54134a2c6652499152112889466dcbc2c8) | `ocamlPackages.kicadsch: init at 0.9`                                                                   |
| [`23028550`](https://github.com/NixOS/nixpkgs/commit/23028550cf3064f519bb302361c9500ebc837f92) | `helix: 22.05 -> 22.08`                                                                                 |
| [`74ca03fa`](https://github.com/NixOS/nixpkgs/commit/74ca03fa3a13003fcc15dc65e9915e2e67c3f959) | `vault-bin: 1.11.1 -> 1.11.3`                                                                           |
| [`a60e0aef`](https://github.com/NixOS/nixpkgs/commit/a60e0aefe66fb70dfcf2f0a69efcc9aa895d951c) | `vault: 1.11.2 -> 1.11.3`                                                                               |
| [`f10333f6`](https://github.com/NixOS/nixpkgs/commit/f10333f64bd91e31a92cb8eb5a5e39114f7a7299) | `nomad_1_3: 1.3.4 -> 1.3.5`                                                                             |
| [`55d61375`](https://github.com/NixOS/nixpkgs/commit/55d613752a5bd73bb318f7714fde3db8eb9d54e8) | `nomad_1_2: 1.2.11 -> 1.2.12`                                                                           |
| [`252244a9`](https://github.com/NixOS/nixpkgs/commit/252244a9fd7b5094ad7806dfb5dc081e1016483a) | `doppler: 3.41.0 -> 3.42.0`                                                                             |
| [`8ea56dfc`](https://github.com/NixOS/nixpkgs/commit/8ea56dfc8f678100dbdc8cd35fcb4b6dae77dc3f) | `samba: don't depend on build python3`                                                                  |
| [`8c680693`](https://github.com/NixOS/nixpkgs/commit/8c68069328de82e719f3c8f94e7745570664e3e1) | `element-{web,desktop}: 1.11.3 -> 1.11.4`                                                               |
| [`5e3c9e7b`](https://github.com/NixOS/nixpkgs/commit/5e3c9e7bb8d9220ab75ec7f0b4057fe2179452d4) | `kubeone: 1.4.7 -> 1.5.0`                                                                               |
| [`3305fd81`](https://github.com/NixOS/nixpkgs/commit/3305fd81772270a25d5b5706690c21f845470886) | `koreader: 2022.07 -> 2022.08`                                                                          |
| [`0374eda4`](https://github.com/NixOS/nixpkgs/commit/0374eda4da18bc5c20f2040e86513b5313b7ae22) | `kics: 1.5.14 -> 1.5.15`                                                                                |
| [`17d6094a`](https://github.com/NixOS/nixpkgs/commit/17d6094ac706ec748ba86bf1680cc74b75492751) | `jsonnet-language-server: 0.7.2 -> 0.8.0`                                                               |
| [`5f3beb0c`](https://github.com/NixOS/nixpkgs/commit/5f3beb0cee74798a056cf2a7dfb91405e149e6fb) | `dbeaver: 22.1.4 -> 22.1.5`                                                                             |
| [`e5069727`](https://github.com/NixOS/nixpkgs/commit/e50697278bf4ff7a1dfc30cbb44f17832d1d1250) | `mathcomp: 1.14.0 -> 1.15.0`                                                                            |
| [`9f3436d2`](https://github.com/NixOS/nixpkgs/commit/9f3436d2fb5c88be4a90749316c9927826abb4e5) | `hugo: 0.102.1 -> 0.102.2`                                                                              |
| [`28912692`](https://github.com/NixOS/nixpkgs/commit/28912692e18584aae54d2fc7a55cd020301c40f3) | `ginkgo: 2.1.5 -> 2.1.6`                                                                                |
| [`9a7bd01e`](https://github.com/NixOS/nixpkgs/commit/9a7bd01e5273ccfff96df172e0df5bb29e34bd1a) | `tailscale: 1.28.0 -> 1.30.0`                                                                           |
| [`df58b081`](https://github.com/NixOS/nixpkgs/commit/df58b081ed80de825239300b7a5192a75cb3f8f9) | `goreleaser: 1.11.1 -> 1.11.2`                                                                          |
| [`f05c5866`](https://github.com/NixOS/nixpkgs/commit/f05c58665b5f06dc21d23f69a5f38410b12890c0) | `python3.pkgs.sphinxcontrib-openapi: link to upstream PR, add maintainers (#189112)`                    |
| [`0cdb86a5`](https://github.com/NixOS/nixpkgs/commit/0cdb86a58e28003c500b810f35174b508cc6e31c) | `amberol: 0.9.0 -> 0.9.1`                                                                               |
| [`cf571a71`](https://github.com/NixOS/nixpkgs/commit/cf571a71b9125798195664aed4b6c77a9ee50fcd) | `qpdf: fix cross-compilation`                                                                           |
| [`5ad2390e`](https://github.com/NixOS/nixpkgs/commit/5ad2390e3dd9c46622191b04f0790b75660efe87) | `dagger: 0.2.31 -> 0.2.32`                                                                              |
| [`54fd3e5b`](https://github.com/NixOS/nixpkgs/commit/54fd3e5b7f3eeea588ecd2d1c4a4c7bc14fab6a9) | `python310Packages.flax: 0.5.2 -> 0.6.0`                                                                |
| [`b598372f`](https://github.com/NixOS/nixpkgs/commit/b598372fd4b46e41da5b759cdd02b73921b8ad67) | `cbfmt: 0.1.4 -> 0.2.0`                                                                                 |
| [`eeefc8f7`](https://github.com/NixOS/nixpkgs/commit/eeefc8f733e7a31c385491685719a68834f5bd4b) | `matrix-synapse: 1.65.0 -> 1.66.0`                                                                      |
| [`ddc111aa`](https://github.com/NixOS/nixpkgs/commit/ddc111aaa89b60509aaad151499099707266bcf1) | `anytype: 0.27.0 -> 0.28.0`                                                                             |
| [`b0eaece3`](https://github.com/NixOS/nixpkgs/commit/b0eaece3d30833ddee187c5ddd40f6200321f680) | `prometheus-sql-exporter: 0.4.4 -> 0.4.5`                                                               |
| [`61621f5b`](https://github.com/NixOS/nixpkgs/commit/61621f5b7e552b4c945519a6ef776aefb68bacc9) | `lnd: 0.15.0-beta -> 0.15.1-beta`                                                                       |
| [`8611f992`](https://github.com/NixOS/nixpkgs/commit/8611f992231063e5acec00eae65ecacd5d7a825d) | `styx: 0.7.2 -> 0.7.5. Fix build failure`                                                               |
| [`e2cc3619`](https://github.com/NixOS/nixpkgs/commit/e2cc36197053c087b16009750fd3e60029600e25) | ``lib.modules: support strings with absolute paths in `disabledModules```                               |
| [`2affab6c`](https://github.com/NixOS/nixpkgs/commit/2affab6cf52750cc16cafbe16fbaffbb663be482) | `keycloak: 18.0.0 -> 19.0.1`                                                                            |
| [`bacac7cf`](https://github.com/NixOS/nixpkgs/commit/bacac7cf54bdfdb41091a506dd1b158da08a2d78) | `sigal: fix crash when building gallery`                                                                |
| [`169ffddd`](https://github.com/NixOS/nixpkgs/commit/169ffddd364d7b02fb344e19a6f93d869b172515) | `Revert "keycloak: 18.0.0 -> 19.0.1"`                                                                   |
| [`4f805873`](https://github.com/NixOS/nixpkgs/commit/4f805873ffad6309fab726bde0a595b1ed9e7c15) | `nearcore: 1.28.0 -> 1.28.1`                                                                            |
| [`2b3ec1d3`](https://github.com/NixOS/nixpkgs/commit/2b3ec1d37a217e690dfd722d0afb90d5c4c156d0) | `lean: 3.47.0 -> 3.48.0`                                                                                |
| [`71d2c6c2`](https://github.com/NixOS/nixpkgs/commit/71d2c6c28c7b7677ea3e65c556e596f9ade324cb) | `rootlesskit: 1.0.0 -> 1.0.1`                                                                           |
| [`a4537570`](https://github.com/NixOS/nixpkgs/commit/a4537570ec4a77180e37f02ec353ca666e213bba) | `trash-cli: 0.22.8.21 -> 0.22.8.27`                                                                     |
| [`9895ba4b`](https://github.com/NixOS/nixpkgs/commit/9895ba4b77ac614a3faba06a53dae5168eaf5c3b) | `tor-browser-bundle-bin: 11.5.1 -> 11.5.2`                                                              |
| [`3968c79e`](https://github.com/NixOS/nixpkgs/commit/3968c79e2aa126b1008ccd630adc2c2173b6f563) | `pipenv: 2022.8.24 -> 2022.8.30`                                                                        |
| [`b77a8d11`](https://github.com/NixOS/nixpkgs/commit/b77a8d11f29c442623acbb5e95b6cd4d08121cd8) | `aws-sdk-cpp: full versions builds fine on x86_64-linux`                                                |
| [`fcfa7a70`](https://github.com/NixOS/nixpkgs/commit/fcfa7a704aa0a317f682aa84b4e34841b28e821e) | `coqPackages.mathcomp-analysis: 0.3.13 → 0.5.3`                                                         |
| [`7460b17d`](https://github.com/NixOS/nixpkgs/commit/7460b17d29d803cda24f429c918cc1ec5379c8ea) | `fluxctl: 1.25.3 -> 1.25.4`                                                                             |
| [`83798399`](https://github.com/NixOS/nixpkgs/commit/83798399409b58958e7e66f2a1ce8800cdf9b397) | `sarasa-gothic: 0.36.8 -> 0.37.0`                                                                       |
| [`fac26c08`](https://github.com/NixOS/nixpkgs/commit/fac26c087f012e656efc242422fc25209c4b49e1) | `digikam: 7.7.0 -> 7.8.0`                                                                               |
| [`e2ccf511`](https://github.com/NixOS/nixpkgs/commit/e2ccf51126a9b6da0f3ca577382696db09d3bc80) | `fennel: 1.1.0 -> 1.2.0`                                                                                |
| [`cd073960`](https://github.com/NixOS/nixpkgs/commit/cd073960275e78625eb20aa0cf1621589d4b61c2) | `wireplumber: backport a fix for bluetooth rescan loops`                                                |
| [`0a18a7c0`](https://github.com/NixOS/nixpkgs/commit/0a18a7c0a0ca74c25fdc1eb1dcb4c677efd43f67) | `czkawka: 5.0.1 -> 5.0.2`                                                                               |
| [`6b9d1e64`](https://github.com/NixOS/nixpkgs/commit/6b9d1e64bef78d1a1b860f23874addbd4478da13) | `dprint: 0.30.3 -> 0.31.1`                                                                              |
| [`2a5171dd`](https://github.com/NixOS/nixpkgs/commit/2a5171ddcc2157078969eb6fe9941c32d0876c82) | `docker-slim: 1.37.6 -> 1.38.0`                                                                         |
| [`e38430fb`](https://github.com/NixOS/nixpkgs/commit/e38430fbd0b796e2a57fdd807e6957e9935da057) | `ocamlPackages.resource-pooling: 1.1 → 1.2`                                                             |
| [`2439b9b4`](https://github.com/NixOS/nixpkgs/commit/2439b9b438b0a85037e4cf09e60809326fd1b2f0) | `cargo-tarpaulin: 0.20.1 -> 0.21.0`                                                                     |
| [`0f4f35c7`](https://github.com/NixOS/nixpkgs/commit/0f4f35c7b05a559bee99bb2be45f850af8e3bda8) | `ocamlPackages.fmt: 0.8.9 → 0.9.0`                                                                      |
| [`2d85fea0`](https://github.com/NixOS/nixpkgs/commit/2d85fea0e2d99fadb5d2e32eb40d9e5d8e40a9ec) | `python310Packages.jmp: 4b94370 -> 260e5ba`                                                             |
| [`a0adbb30`](https://github.com/NixOS/nixpkgs/commit/a0adbb308c6775bed2ea513b24556a4da06fbf87) | `python310Packages.chex: 0.1.3 -> 0.1.4`                                                                |
| [`6623fff5`](https://github.com/NixOS/nixpkgs/commit/6623fff5f88f29179c7bd5d37954fe302d900cae) | `alfaview: 8.51.0 -> 8.52.0`                                                                            |
| [`30942c90`](https://github.com/NixOS/nixpkgs/commit/30942c90cbdf884dc6df63fbec859ac812e7d9d1) | `python310Packages.sorl_thumbnail: 12.8.0 -> 12.9.0`                                                    |
| [`1b2b9970`](https://github.com/NixOS/nixpkgs/commit/1b2b9970ad6b63b6718a5293ef182d0cca951418) | `python310Packages.telethon: 1.24.0 -> 1.25.0`                                                          |
| [`95412505`](https://github.com/NixOS/nixpkgs/commit/954125059c9f53097648b31a7ae2bf0516a43f86) | `python310Packages.types-redis: 4.3.18 -> 4.3.19`                                                       |
| [`69ccd66a`](https://github.com/NixOS/nixpkgs/commit/69ccd66a735d408d991530566c0f558b41ea3e00) | `krita: 5.0.8 -> 5.1.0`                                                                                 |
| [`1b35942c`](https://github.com/NixOS/nixpkgs/commit/1b35942cbb016de93d59375c4ad3086441dc5b25) | `python310Packages.versioneer: 0.23 -> 0.24`                                                            |
| [`e4569399`](https://github.com/NixOS/nixpkgs/commit/e4569399a758a6aac605a6f861f14aa402a982c1) | `taplo-lsp: remove unnecessary file`                                                                    |
| [`5f190380`](https://github.com/NixOS/nixpkgs/commit/5f190380aed4f4394c1d30972a52b6a2cdd63d9e) | `discord-canary: 0.0.136 -> 0.0.137`                                                                    |
| [`15884ce8`](https://github.com/NixOS/nixpkgs/commit/15884ce84ac1bf32f7643d9c44ac7a1d994f2ecd) | `gnome-frog: correct build inputs list`                                                                 |
| [`d4ada975`](https://github.com/NixOS/nixpkgs/commit/d4ada975204705bb70d77bd196d2b969668fc540) | `grafana-image-renderer: 3.4.0 -> 3.6.1 (CVE-2022-31176)`                                               |
| [`9f1a83cc`](https://github.com/NixOS/nixpkgs/commit/9f1a83ccc753c498ab30527925a6db6a1f379ecf) | `grafana: 9.1.1 -> 9.1.2 (CVE-2022-31176)`                                                              |
| [`2e4e7dd7`](https://github.com/NixOS/nixpkgs/commit/2e4e7dd7eb842d04b85bfa81c48a820220acb5d5) | `python310Packages.python-ironicclient: 5.0.0 -> 5.0.1`                                                 |
| [`b4c8635e`](https://github.com/NixOS/nixpkgs/commit/b4c8635e39863584bf027ba0a6e3c3e76e095997) | `python310Packages.python-gitlab: 3.8.1 -> 3.9.0`                                                       |
| [`52e621ac`](https://github.com/NixOS/nixpkgs/commit/52e621ace8e82f771f7be251e6b1ecb5ec7c2e2b) | `nixos/kea: fix ctrl-agent extraArgs`                                                                   |
| [`50e7538f`](https://github.com/NixOS/nixpkgs/commit/50e7538f3e57eaa3ebd8778903204ef39b7d8129) | `chromiumDev: 106.0.5245.0 -> 106.0.5249.12`                                                            |
| [`7db78348`](https://github.com/NixOS/nixpkgs/commit/7db783480722aecf1e578e9d147cb4516160ec22) | `python310Packages.pylibmc: 1.6.2 -> 1.6.3`                                                             |
| [`49263eb8`](https://github.com/NixOS/nixpkgs/commit/49263eb8dcf335f2eca0f490eb8e6e4fc00d5f66) | `python310Packages.pydata-sphinx-theme: 0.9.0 -> 0.10.1`                                                |
| [`6d09a026`](https://github.com/NixOS/nixpkgs/commit/6d09a0268c8082923cbee097ef40af07f6340b13) | `python310Packages.oslo-db: 12.0.0 -> 12.1.0`                                                           |
| [`3b6f1cfc`](https://github.com/NixOS/nixpkgs/commit/3b6f1cfcf9a7fdac1dc78de2edb10031574c2ebb) | `gitlab: 15.3.1 -> 15.3.2 (#189005)`                                                                    |
| [`a7951df2`](https://github.com/NixOS/nixpkgs/commit/a7951df278adb5be699603eb960b802ec5713853) | `python310Packages.minikerberos: 0.2.20 -> 0.3.0`                                                       |
| [`956618e8`](https://github.com/NixOS/nixpkgs/commit/956618e8d42e88052b30fabf2966c005fb3cbe69) | `cargo-semver-checks: init at 0.9.2`                                                                    |
| [`46322929`](https://github.com/NixOS/nixpkgs/commit/463229292d6b61fbff8a60d24dac0a22de2909c3) | `elmPackages.lamdera: homepage from URL literal to string`                                              |
| [`f58bdc5d`](https://github.com/NixOS/nixpkgs/commit/f58bdc5d4cbb6da8d8d43e8ea53daf0549b92895) | `werf: 1.2.165 -> 1.2.166`                                                                              |
| [`0be3a104`](https://github.com/NixOS/nixpkgs/commit/0be3a104aaac9bc4aec1b38e46e075fbde6522aa) | `systeroid: 0.2.0 -> 0.2.1`                                                                             |
| [`87414a57`](https://github.com/NixOS/nixpkgs/commit/87414a5738031cba923132172a894fae147cb7c3) | `python310Packages.peaqevcore: 5.16.7 -> 5.18.1`                                                        |
| [`3bfe6bfc`](https://github.com/NixOS/nixpkgs/commit/3bfe6bfca2fbe5f7f6c9d640172d482bfdcec815) | `openscad: add patches for CVE-2022-0496 & CVE-2022-0497`                                               |
| [`69e85c98`](https://github.com/NixOS/nixpkgs/commit/69e85c98a60aec085b9c558eb9a1781f60d43a97) | `cvise: 2.4.0 -> 2.5.0`                                                                                 |
| [`4e5a4eb4`](https://github.com/NixOS/nixpkgs/commit/4e5a4eb4d617575f3163228ebb0feab41c24eb5d) | `psst: add .desktop file`                                                                               |
| [`3402d9c4`](https://github.com/NixOS/nixpkgs/commit/3402d9c4a4fe77e245c1b3b061997a83e6f7504e) | `python3Packages.sanic: add patch for CVE-2022-35920`                                                   |
| [`2a494cae`](https://github.com/NixOS/nixpkgs/commit/2a494cae1ede37303bc01c645512bbef6b6f8c25) | `pwndbg: 2022.01.05 -> 2022.08.30`                                                                      |
| [`83a5f628`](https://github.com/NixOS/nixpkgs/commit/83a5f62886c8df8e9fb7ff4561a537b64a492db9) | `beamerpresenter-poppler: init at 0.2.2`                                                                |
| [`4b24143b`](https://github.com/NixOS/nixpkgs/commit/4b24143bf5a27b26b70466a21d11d716100f0c66) | `qt6Packages.poppler: init at 22.08.0`                                                                  |
| [`ce1e76ef`](https://github.com/NixOS/nixpkgs/commit/ce1e76efe8659ec7f22bcb539bb872a56814e67b) | `oh-my-posh: 8.36.1 -> 8.36.4`                                                                          |
| [`ef49a845`](https://github.com/NixOS/nixpkgs/commit/ef49a84500e0bdcb31668c24fa906008ebe9c821) | `python3Packages.coinmetrics-api-client: init at 2022.8.29.6`                                           |
| [`c335189e`](https://github.com/NixOS/nixpkgs/commit/c335189e81d35885fc797bc2a25469693055a916) | `elmPackages.lamdera: init at 1.0.1`                                                                    |
| [`bcf56ef8`](https://github.com/NixOS/nixpkgs/commit/bcf56ef81d32d2e1073a275eca1a6ef056410a49) | `mympd: 9.5.2 -> 9.5.3`                                                                                 |
| [`5391dc4f`](https://github.com/NixOS/nixpkgs/commit/5391dc4fd00f77c8b56eb94c39c6aafb8f747274) | `goreleaser: 1.10.3 -> 1.11.1`                                                                          |
| [`afe8ee8b`](https://github.com/NixOS/nixpkgs/commit/afe8ee8b470974ef8f8ce17a316c6ac8eb30df15) | `python3Packages.torch{,-bin}: rename from pytorch{,-bin}`                                              |
| [`bafce1c7`](https://github.com/NixOS/nixpkgs/commit/bafce1c7cdaed1af39b804a660aa3ce6307886af) | `mmark: 2.2.26 -> 2.2.28`                                                                               |
| [`1925106b`](https://github.com/NixOS/nixpkgs/commit/1925106bf1d9de60ffd6d66d90d5117f7c18dfd9) | `minio-client: 2022-08-23T05-45-20Z -> 2022-08-28T20-08-11Z`                                            |
| [`a6be71e6`](https://github.com/NixOS/nixpkgs/commit/a6be71e6fc1a7f6a3dcdf97093db4b9ffa395d80) | `aws-sdk-cpp: unpin i686 instead remove failing test and mark broken when building ec2, little cleanup` |
| [`e7ea2829`](https://github.com/NixOS/nixpkgs/commit/e7ea2829dc9a56b74375ccb74159ebf786a61f1d) | `limesctl: 3.0.0 -> 3.0.2`                                                                              |
| [`577aecb7`](https://github.com/NixOS/nixpkgs/commit/577aecb787dd87bee7de2cad6f6662ad019f505f) | `libcouchbase: 3.3.1 -> 3.3.2`                                                                          |
| [`c6239c5d`](https://github.com/NixOS/nixpkgs/commit/c6239c5de0aa6075cd21f7059f96e8e8e3a635d2) | `ocamlPackages.lwt_log: 1.1.1 → 1.1.2`                                                                  |