### PR TITLE
chore(flake/naersk): `cddffb5a` -> `c6a45e42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message             |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`c6a45e42`](https://github.com/nix-community/naersk/commit/c6a45e4277fa58abd524681466d3450f896dc094) | `Revamp examples & README` |