### PR TITLE
chore(flake/pre-commit): `8cb8ea5f` -> `2a4f1cfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660830093,
-        "narHash": "sha256-HUhx3a82C7bgp2REdGFeHJdhEAzMGCk3V8xIvfBqg1I=",
+        "lastModified": 1664573419,
+        "narHash": "sha256-bVjsFPOF4t5/G9ir/qNqmQWxRKooG86ctOH78yaarkc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cb8ea5f1c7bc2984f460587fddd5f2e558f6eb8",
+        "rev": "2a4f1cfaa01b8b31edc7d3004454c4a0c38d50d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                       |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`e48619d6`](https://github.com/cachix/pre-commit-hooks.nix/commit/e48619d65be73a2fc1c80ea5c3036b3c5c31caa2) | `fix(nix/tools): get chktex, latexindent from texlive.scheme-medium` |
| [`b29df527`](https://github.com/cachix/pre-commit-hooks.nix/commit/b29df5277e316f2c8845532c49c6a9d03d449485) | `style(nix/tools): also sort inherits and callPackage lines`         |
| [`b35118da`](https://github.com/cachix/pre-commit-hooks.nix/commit/b35118daf6afc1f4c5f09dde0e02a9c15d2bf2d1) | `feat(modules/hooks): add latexindent`                               |
| [`65348b66`](https://github.com/cachix/pre-commit-hooks.nix/commit/65348b66411582328a68158696e89a85f38ec646) | `feat(modules/hooks): add chktex`                                    |
| [`d21b1161`](https://github.com/cachix/pre-commit-hooks.nix/commit/d21b1161b05c65f46c9af8b54cb1e3195f7141cb) | `style(nix/tools): sort inputs`                                      |
| [`3424c610`](https://github.com/cachix/pre-commit-hooks.nix/commit/3424c6107bde3bdb84eada83db7f4bc6f0d346e4) | `feat(modules/hooks): add actionlint`                                |
| [`02e36c77`](https://github.com/cachix/pre-commit-hooks.nix/commit/02e36c77d93f04fc29cc4ba31ec4659f30056f31) | `feat(modules/hooks): add luacheck`                                  |
| [`bb7a22b4`](https://github.com/cachix/pre-commit-hooks.nix/commit/bb7a22b4bde48916b70af1f482e3b9c65cd51dd9) | `fix rustfmt`                                                        |