### PR TITLE
chore(flake/rust): `fae4c320` -> `fa6d41ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662519741,
-        "narHash": "sha256-SrtSAMkTri4KseXliYfOjz9qqGAlX/L+ZZDHAMkYfh0=",
+        "lastModified": 1664507051,
+        "narHash": "sha256-Trcnn5Ll7UXFqMQP7jCwwIypCQhfHQGRjrWVVbY74Uw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fae4c3204fb45876f8b54ab1e982de8896269868",
+        "rev": "fa6d41ac91f44ce9a90ca08e7a3ff5abf88e77a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message     |
| ----------------------------------------------------------------------------------------------------- | ------------------ |
| [`fa6d41ac`](https://github.com/oxalica/rust-overlay/commit/fa6d41ac91f44ce9a90ca08e7a3ff5abf88e77a1) | `manifest: update` |
| [`1601b5a2`](https://github.com/oxalica/rust-overlay/commit/1601b5a28c50fd9d40bd61b8878f3499e09bce7a) | `manifest: update` |
| [`70eab96a`](https://github.com/oxalica/rust-overlay/commit/70eab96a255ae9b4b82b38ea5ac5c8e5b57e0abd) | `manifest: update` |
| [`524db9c9`](https://github.com/oxalica/rust-overlay/commit/524db9c9ea7bc7743bb74cdd45b6d46ea3fcc2ab) | `manifest: update` |
| [`e6c6adb0`](https://github.com/oxalica/rust-overlay/commit/e6c6adb0438a46baaf820d3f52ca587b44437d34) | `manifest: update` |
| [`45140fa5`](https://github.com/oxalica/rust-overlay/commit/45140fa526b1cb85498f717e355c79a54367cb1d) | `manifest: update` |
| [`6eb90123`](https://github.com/oxalica/rust-overlay/commit/6eb90123f46664ffbb550c527f656ba848718af5) | `manifest: update` |
| [`9e319dd1`](https://github.com/oxalica/rust-overlay/commit/9e319dd18f7beadab4daaf2426466d4023c1d26f) | `manifest: update` |
| [`f45f856a`](https://github.com/oxalica/rust-overlay/commit/f45f856ae5a9fe2c48d756fa17bb9c5b3b8070c5) | `manifest: update` |
| [`0300688a`](https://github.com/oxalica/rust-overlay/commit/0300688a98e053712108d4e22d5bdcf9c9106d8c) | `manifest: update` |
| [`c9cfed98`](https://github.com/oxalica/rust-overlay/commit/c9cfed9847475dcfc8b821d6ccb0c5229b4130a1) | `manifest: update` |
| [`0be459ed`](https://github.com/oxalica/rust-overlay/commit/0be459ed341465ed6c9611da9209f603c04e5f07) | `manifest: update` |
| [`2ac8be33`](https://github.com/oxalica/rust-overlay/commit/2ac8be332f507e521c235caa37cb0b2fc698cbd9) | `manifest: update` |
| [`e4c6adaa`](https://github.com/oxalica/rust-overlay/commit/e4c6adaa5f9293911de5ad50eaf32dbe36819de3) | `manifest: update` |
| [`0678b618`](https://github.com/oxalica/rust-overlay/commit/0678b6187a153eb0baa9688335b002fe14ba6712) | `manifest: update` |
| [`f34d44ae`](https://github.com/oxalica/rust-overlay/commit/f34d44aef4ca7c11e66ed30ef46a93058a578c0f) | `manifest: update` |
| [`a65e63f1`](https://github.com/oxalica/rust-overlay/commit/a65e63f15f1889c053f833767c7d624ccfba3110) | `manifest: update` |
| [`dbd08f5b`](https://github.com/oxalica/rust-overlay/commit/dbd08f5b5469e1e24f00de45ddc73c26290a2bcb) | `manifest: update` |
| [`d88cd53d`](https://github.com/oxalica/rust-overlay/commit/d88cd53d7bc148b5979175b8f3e6e86b477fe715) | `manifest: update` |
| [`c4277c59`](https://github.com/oxalica/rust-overlay/commit/c4277c59580939c0a3d0d0325b9ea13e071873ec) | `manifest: update` |
| [`70d8df25`](https://github.com/oxalica/rust-overlay/commit/70d8df25fbe9cc5c74900b11d06ef120200f3948) | `manifest: update` |
| [`2be26531`](https://github.com/oxalica/rust-overlay/commit/2be265312c3ad66a23538b497de6fda534ead172) | `manifest: update` |
| [`10ecf9db`](https://github.com/oxalica/rust-overlay/commit/10ecf9db483f157d86e03edbae0ba48f613abfa4) | `manifest: update` |