### PR TITLE
chore(flake/pre-commit): `2a4f1cfa` -> `1b436f36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664573419,
-        "narHash": "sha256-bVjsFPOF4t5/G9ir/qNqmQWxRKooG86ctOH78yaarkc=",
+        "lastModified": 1666604592,
+        "narHash": "sha256-Bxy7xeVAwC0yxFaeYZM7N9Us/ebxpMC9TCceKEFeay4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2a4f1cfaa01b8b31edc7d3004454c4a0c38d50d8",
+        "rev": "1b436f36e2812c589e6d830e3223059ea9661100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`364f8c3c`](https://github.com/cachix/pre-commit-hooks.nix/commit/364f8c3c66f4326992264fac489a0d4e634248d6) | `README: elaborate on closure size check`                   |
| [`34b86a5c`](https://github.com/cachix/pre-commit-hooks.nix/commit/34b86a5c64299f5c621e05556a6788e0fe8c1621) | `feat: add govet hook`                                      |
| [`48298faa`](https://github.com/cachix/pre-commit-hooks.nix/commit/48298faa3cba195b264e6cc92a4b054284489b37) | `chore(deps): bump cachix/install-nix-action from 17 to 18` |
| [`71d0c678`](https://github.com/cachix/pre-commit-hooks.nix/commit/71d0c678c3e0e527fbd6574838160f2eab04aa1a) | `chore(deps): bump cachix/cachix-action from 10 to 11`      |
| [`fb9ffa12`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb9ffa12010607eb60e77e9591d286f76588e9fd) | `Make cabal2nix work in subdirectories as well`             |
| [`a0bb790b`](https://github.com/cachix/pre-commit-hooks.nix/commit/a0bb790b261f7dd1d83b2ed5beaaaa69357b2618) | `Cabal2nix hook`                                            |
| [`380f0846`](https://github.com/cachix/pre-commit-hooks.nix/commit/380f08460be3f1ddd3bceb6cfb505de5d8e479e0) | `Fix name of elm-test hook`                                 |
| [`1d9721d0`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d9721d04974f738b12ca5e9748bd683518785ed) | ``Run nixpkgs-fmt on `modules/hooks.nix```                  |
| [`4884c714`](https://github.com/cachix/pre-commit-hooks.nix/commit/4884c714d67ea89ed6adf49601adf6b2c64eeab0) | `Add support for deadnix`                                   |
| [`efcbfd78`](https://github.com/cachix/pre-commit-hooks.nix/commit/efcbfd78c7ec5748114b33cb48a6b26ddb7e29dd) | `Add dhall-format for formatting Dhall code`                |