### PR TITLE
chore(flake/crane): `755acd23` -> `ee00efb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,14 +8,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1664412889,
-        "narHash": "sha256-gyVtTQf3CiXLe1cwNRFxqUqYl9BCmIDvK7hIpzR/oQU=",
+        "lastModified": 1667069801,
+        "narHash": "sha256-tDmoGtMt/SwfZdZvJdxsnZUcpXa78+Eeeqs13kNqLG8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "755acd231a7de182fdc772bee1b2a1f21d4ec9ed",
+        "rev": "ee00efb961bc3e594270f383ea4f74817f18f462",
         "type": "github"
       },
       "original": {
@@ -139,6 +140,31 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "fa6d41ac91f44ce9a90ca08e7a3ff5abf88e77a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666494036,
+        "narHash": "sha256-4mmm+1MBPMD56LMLN9QcEwnfnu41NkA6lDeZGjSrxIw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "af2e939ba2c7cbb188d06d6650c6353b10b3f2be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`ee00efb9`](https://github.com/ipetkov/crane/commit/ee00efb961bc3e594270f383ea4f74817f18f462) | `registryFromGitIndex: use shallow git checkouts (#151)`                           |
| [`975bda72`](https://github.com/ipetkov/crane/commit/975bda728a93c1882176e90e9e79c16fcfa48b65) | `Change default cargo artifact installation to use symlinks where possible (#150)` |
| [`f48777a9`](https://github.com/ipetkov/crane/commit/f48777a96601e8fa3f537f3cab22d7a858bcde19) | `Update CHANGELOG`                                                                 |
| [`2ce1a331`](https://github.com/ipetkov/crane/commit/2ce1a3313e299b0db63b11f94c863af74b0b08ad) | `Eliminate dead code (#148)`                                                       |
| [`6b864957`](https://github.com/ipetkov/crane/commit/6b864957e1ac008cb04f8b53353b6fb8ea349c51) | `checks: add tests for building crates using workspace inheritance (#147)`         |
| [`bdea4519`](https://github.com/ipetkov/crane/commit/bdea451966ed41ed08e7f670518f1cfa8cb1ebcc) | `Update flake.lock (#146)`                                                         |
| [`4d6f7497`](https://github.com/ipetkov/crane/commit/4d6f74978e6b56416772094c31851ae005602039) | `ci: disable automatic approval for flake update workflow`                         |
| [`af1da2f2`](https://github.com/ipetkov/crane/commit/af1da2f2712261d0f1879e95eef0ad3afb562958) | `ci: rewrite flake update workflow`                                                |
| [`eadc1153`](https://github.com/ipetkov/crane/commit/eadc11533bbd3525773de34deb7c8d7d7692c4f6) | `ci: schedule periodic flake updates`                                              |
| [`a7e27ff4`](https://github.com/ipetkov/crane/commit/a7e27ff425641dcb8cfa926871209eebe343ec67) | `ci: actually update the flake`                                                    |
| [`9ed120ca`](https://github.com/ipetkov/crane/commit/9ed120ca5022035ffacd784cc492b5ab085969b5) | `ci: move test logic into a script`                                                |
| [`9c16d693`](https://github.com/ipetkov/crane/commit/9c16d69328bcb774633ce5ba7032cf320116402d) | `ci: allow test workflow to be called`                                             |
| [`77dcc131`](https://github.com/ipetkov/crane/commit/77dcc1315f0be8cafaf20858d9701954c33eac7b) | `ci: update workflow`                                                              |
| [`e98f7263`](https://github.com/ipetkov/crane/commit/e98f7263f43cc3e090f1a0852cff6e821be3634d) | `ci: Add workflow for updating flake dependencies`                                 |
| [`097afacc`](https://github.com/ipetkov/crane/commit/097afacc53a0a5fc23c212e5fe2a337ea53cdf0b) | `mkDummySrc: support freestanding targets (#126)`                                  |
| [`1bea2b52`](https://github.com/ipetkov/crane/commit/1bea2b52128832ab0e94370930e96ff0c99cf464) | `crateNameFromCargoToml: handle workspace inheritance (#144)`                      |
| [`d78cb045`](https://github.com/ipetkov/crane/commit/d78cb0453b9823d2102f7b22bb98686215462416) | `cargoBuild: do not run tests`                                                     |
| [`b84c191b`](https://github.com/ipetkov/crane/commit/b84c191b59a5b211349229bb4fe88b34654ece56) | ``buildDepsOnly: accept `cargo{Check,Test}ExtraArgs```                             |
| [`17f4ff6a`](https://github.com/ipetkov/crane/commit/17f4ff6ad779fd6e854bbb035b32ac9b7d4e1f26) | `buildPackage: use mkCargoDerivation instead of cargoBuild`                        |
| [`f27d6dd4`](https://github.com/ipetkov/crane/commit/f27d6dd45d8137d4bbb7bd36f3899311d65f3536) | ``cargoTarpaulin: require that `cargoArtifacts` are specified``                    |
| [`1020bbe7`](https://github.com/ipetkov/crane/commit/1020bbe7ddc949dd3cd69724bdb683c668ac856a) | ``Remove deprecated `package` bindings``                                           |
| [`f2a92d60`](https://github.com/ipetkov/crane/commit/f2a92d6010461337b0b55951c103c9ece43f1736) | `Update CHANGELOG`                                                                 |
| [`a1e9a419`](https://github.com/ipetkov/crane/commit/a1e9a4197c69116a286898c2a86846c2d7199111) | `Fixup docs (#133)`                                                                |
| [`0b71f12f`](https://github.com/ipetkov/crane/commit/0b71f12fc75c45a71cf7814ff2f4d286de95c0c0) | `Add cargoTest for running crate tests (#132)`                                     |
| [`1127ed25`](https://github.com/ipetkov/crane/commit/1127ed2587dc1e23ab8dc41e20b5ec35933e5714) | `cargoNextest: use mkCargoDerivation instead of cargoBuild`                        |
| [`2b70a82c`](https://github.com/ipetkov/crane/commit/2b70a82caf03c0db6fc1c3eacfd341958b1ae4cf) | `cargoClippy: use mkCargoDerivation instead of cargoBuild`                         |
| [`0ad37656`](https://github.com/ipetkov/crane/commit/0ad37656bc41d2d0c6aa3a716771884b8bd8306d) | `cargoTarpaulin: use mkCargoDerivation instead of cargoBuild`                      |
| [`8c97f064`](https://github.com/ipetkov/crane/commit/8c97f0644890c4e787444a303c11b4347bb860ca) | `cargoAudit: use mkCargoDerivation instead of cargoBuild`                          |
| [`b61434b0`](https://github.com/ipetkov/crane/commit/b61434b0b2b253c10c0bf67c0f0d494a78dc6020) | `cargoDoc: use mkCargoDerivation instead of cargoBuild`                            |
| [`51bbfae3`](https://github.com/ipetkov/crane/commit/51bbfae3f65e307e1139faa3b93ef8cb5d7cc121) | `cargoFmt: use mkCargoDerivation instead of cargoBuild`                            |
| [`cc7d69f1`](https://github.com/ipetkov/crane/commit/cc7d69f1edd9f1e44e3e3dbdaa615f5315fdc71f) | `mkCargoDerivation: default to empty checkPhaseCargoCommand`                       |
| [`d4a3bee7`](https://github.com/ipetkov/crane/commit/d4a3bee75f042f598862340b42d51203be1e69c4) | `mkCargoDerivation: populate pname and version if not specified`                   |
| [`d3db2ecf`](https://github.com/ipetkov/crane/commit/d3db2ecf0101e14ff361c9a2ecf6ce00a193e27d) | `mkCargoDerivation: automatically vendor deps if cargoVendorDir not set`           |
| [`0017a8da`](https://github.com/ipetkov/crane/commit/0017a8da6824c5f27c48cce7d614d3e590e75e35) | ``flake: deprecate the `packages` flake output (#130)``                            |
| [`37def1e9`](https://github.com/ipetkov/crane/commit/37def1e9c317dba1c7def2f7c011bb09f2645e5d) | `readme: update with advice on patching Cargo.lock (#129)`                         |
| [`fc545e67`](https://github.com/ipetkov/crane/commit/fc545e6784c2f07000a52546f7c8514fcc5aa557) | `hooks: do not use substitutions for needed tools (#128)`                          |