### PR TITLE
chore(flake/rust): `fa6d41ac` -> `8f81faec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664507051,
-        "narHash": "sha256-Trcnn5Ll7UXFqMQP7jCwwIypCQhfHQGRjrWVVbY74Uw=",
+        "lastModified": 1667184938,
+        "narHash": "sha256-/kuCiXuAxiD0c0zrfDvJ1Yba3FuVdRk/ROfb393AeX4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fa6d41ac91f44ce9a90ca08e7a3ff5abf88e77a1",
+        "rev": "8f81faec35508647ced65c44fd3e8648a5518afb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`8f81faec`](https://github.com/oxalica/rust-overlay/commit/8f81faec35508647ced65c44fd3e8648a5518afb) | `manifest: update`                                                                            |
| [`de5c4d5d`](https://github.com/oxalica/rust-overlay/commit/de5c4d5d40ae0a0dab67c5f7ae8d26c5445cf00d) | `manifest: update`                                                                            |
| [`34d76c0a`](https://github.com/oxalica/rust-overlay/commit/34d76c0a001d81a0fac342698ce7926da37b8ea5) | `manifest: update`                                                                            |
| [`4b1fcd57`](https://github.com/oxalica/rust-overlay/commit/4b1fcd5766db910c07c871d1454b1fe296e4547c) | `manifest: update`                                                                            |
| [`c095030c`](https://github.com/oxalica/rust-overlay/commit/c095030cf6c84e304f867ad066d8d5b051131af5) | `manifest: update`                                                                            |
| [`b20d7b01`](https://github.com/oxalica/rust-overlay/commit/b20d7b01b37268f240d185f5a2902d5fecb48ad3) | `manifest: update`                                                                            |
| [`79b6e66b`](https://github.com/oxalica/rust-overlay/commit/79b6e66bb76537c96707703f08630765e46148d1) | `manifest: update`                                                                            |
| [`b5029501`](https://github.com/oxalica/rust-overlay/commit/b502950146a6089c3ac017e567899c0b65e649fc) | `manifest: update`                                                                            |
| [`af2e939b`](https://github.com/oxalica/rust-overlay/commit/af2e939ba2c7cbb188d06d6650c6353b10b3f2be) | `manifest: update`                                                                            |
| [`8ffc6342`](https://github.com/oxalica/rust-overlay/commit/8ffc63427df1dc7e53fb96cb13b130028c258202) | `manifest: update`                                                                            |
| [`5f0aea62`](https://github.com/oxalica/rust-overlay/commit/5f0aea6238cfc6891dfed525f01a1d84297e1723) | `manifest: update`                                                                            |
| [`e9f3513b`](https://github.com/oxalica/rust-overlay/commit/e9f3513b1b43aed7361b62a4054a07f4fabc5105) | `pkgconfig is now pkg-config`                                                                 |
| [`dd334e95`](https://github.com/oxalica/rust-overlay/commit/dd334e95eb46e79e52a75c80ef9ba73c3d867840) | `manifest: update`                                                                            |
| [`3e41700a`](https://github.com/oxalica/rust-overlay/commit/3e41700ab6f585b9569112ee7516c74f8d072989) | `manifest: update`                                                                            |
| [`8643439d`](https://github.com/oxalica/rust-overlay/commit/8643439d1db65a33ca6813d0aa8956b2be4bd91d) | `manifest: update`                                                                            |
| [`ae87512a`](https://github.com/oxalica/rust-overlay/commit/ae87512a3e8ee5bfffd42dadce041e7bdcd05a38) | `manifest: update`                                                                            |
| [`5b3346ac`](https://github.com/oxalica/rust-overlay/commit/5b3346acfbb67bfbf15983dce0b101b24b185d1f) | `manifest: update`                                                                            |
| [`f55e3d74`](https://github.com/oxalica/rust-overlay/commit/f55e3d741c6fe357d1e1bea50f5916863c831fdc) | `manifest: update`                                                                            |
| [`aa3bcc3f`](https://github.com/oxalica/rust-overlay/commit/aa3bcc3fb5ff01cb1923ff36162e80582ac335db) | `manifest: update`                                                                            |
| [`73650741`](https://github.com/oxalica/rust-overlay/commit/73650741960a7422d1422f156f76211e576610c2) | `manifest: update`                                                                            |
| [`8c727f07`](https://github.com/oxalica/rust-overlay/commit/8c727f07aa0ce5b618a3c653da75ace830485b21) | `manifest: update`                                                                            |
| [`5066af87`](https://github.com/oxalica/rust-overlay/commit/5066af8707c4b598ad2dbfb2fdac73714bee3438) | `manifest: update`                                                                            |
| [`af29a900`](https://github.com/oxalica/rust-overlay/commit/af29a900f10dd6e467622202fb4f6d944d72a3a6) | `Update dependencies`                                                                         |
| [`32edf101`](https://github.com/oxalica/rust-overlay/commit/32edf1012eb5461cf137e6ca97e710c10d03a728) | `Try to fix CI`                                                                               |
| [`c1e8d766`](https://github.com/oxalica/rust-overlay/commit/c1e8d766436179b622af088b3dbf1181264c18ba) | `manifest: update`                                                                            |
| [`440a5c8b`](https://github.com/oxalica/rust-overlay/commit/440a5c8ba3d025a8e3f787ebd7e7b8091964e064) | `manifest: update`                                                                            |
| [`ad99d2a8`](https://github.com/oxalica/rust-overlay/commit/ad99d2a83db05d1c5caae4ac96f0515ba6f2b6df) | `manifest: update`                                                                            |
| [`fb8f4fa9`](https://github.com/oxalica/rust-overlay/commit/fb8f4fa9c5514dbbc7d2a7c310d8ba874c519779) | `manifest: update`                                                                            |
| [`fb4d8ee5`](https://github.com/oxalica/rust-overlay/commit/fb4d8ee5220b76d1ffb4b4e1fedcf3cbc93ead1a) | `manifest: update`                                                                            |
| [`e6531ebf`](https://github.com/oxalica/rust-overlay/commit/e6531ebf628998fd03f6e5f4e3939b34bfd374f3) | `manifest: update`                                                                            |
| [`148815c9`](https://github.com/oxalica/rust-overlay/commit/148815c92641976b798efb2805a50991de4bac7f) | `manifest: update`                                                                            |
| [`5db6b631`](https://github.com/oxalica/rust-overlay/commit/5db6b63124ccedd61e896ec98def85fb4e6668f4) | `Update docs to use rust-overlay.overlays.default instead of deprecated rust-overlay.overlay` |
| [`a09b0758`](https://github.com/oxalica/rust-overlay/commit/a09b07580c024fa08aa33dab9b4fae16be3f71bd) | `manifest: update`                                                                            |
| [`f48045bb`](https://github.com/oxalica/rust-overlay/commit/f48045bb46f6eef8314b9fe01b7db9dcdbca1e10) | `manifest: update`                                                                            |