### PR TITLE
chore(flake/nixpkgs): `854fdc68` -> `412b9917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664370076,
-        "narHash": "sha256-NDnIo0nxJozLwEw0VPM+RApMA90uTfbvaNNtC5eB7Os=",
+        "lastModified": 1667142599,
+        "narHash": "sha256-OLJxsg9VqfKjFkerOxWtNIkibsCvxsv5A8wNWO1MeWk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "854fdc68881791812eddd33b2fed94b954979a8e",
+        "rev": "412b9917cea092f3d39f9cd5dead4effd5bc4053",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`593929c7`](https://github.com/NixOS/nixpkgs/commit/593929c7484e1113b6759c69bcd27993b7fa2347) | `xfe: use xorg.* packages directly instead of xlibsWrapper indirection`               |
| [`229fa2fd`](https://github.com/NixOS/nixpkgs/commit/229fa2fd6da968085fc3a4225c5ed84ab76fc02b) | `xautolock: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`bfa19140`](https://github.com/NixOS/nixpkgs/commit/bfa191404f33bc72d6b6fa1647ea3462ebacdbe4) | `voxelands: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`3809602f`](https://github.com/NixOS/nixpkgs/commit/3809602fd4cc838f0a35e79f94afed056db814cc) | `wordnet: drop unused xlibsWrapper`                                                   |
| [`3fd2a244`](https://github.com/NixOS/nixpkgs/commit/3fd2a24468aad7fc0faab16fcd639c2dbb36be58) | `bitcoind-knots: 22.0.knots20211108 -> 23.0.knots20220529`                            |
| [`3d5f6e4c`](https://github.com/NixOS/nixpkgs/commit/3d5f6e4c314662988aeb49680f431bfc5e23dea6) | `unclutter-xfixes: use xorg.* packages directly instead of xlibsWrapper indirection`  |
| [`d9ffff59`](https://github.com/NixOS/nixpkgs/commit/d9ffff599a22c8091687d4e5f56140a838ba337a) | `unclutter: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`e8229690`](https://github.com/NixOS/nixpkgs/commit/e8229690bb1fdc41b44fbc432a0df559bd6457cc) | `pasystray: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`f88447d1`](https://github.com/NixOS/nixpkgs/commit/f88447d108b9da9dbf300fb7b249e703ac8a9e53) | `soxt: use xorg.* packages directly instead of xlibsWrapper indirection`              |
| [`d5b82c0a`](https://github.com/NixOS/nixpkgs/commit/d5b82c0a63c9faea8109c04f243aab7dafb2cd76) | `fox: use xorg.* packages directly instead of xlibsWrapper indirection`               |
| [`b4530d1e`](https://github.com/NixOS/nixpkgs/commit/b4530d1ed4f3dc5cbf1d2a08fb8ed4cbb5b94114) | `povray: use xorg.* packages directly instead of xlibsWrapper indirection`            |
| [`d09843bf`](https://github.com/NixOS/nixpkgs/commit/d09843bf11098b696fc2831f47287369745c6a56) | `blender: 3.3.0 -> 3.3.1`                                                             |
| [`4cef88b8`](https://github.com/NixOS/nixpkgs/commit/4cef88b8526cd9de2eb742fea179e169ed7d8a7b) | `openrw: use xorg.* packages directly instead of xlibsWrapper indirection`            |
| [`4eb6161e`](https://github.com/NixOS/nixpkgs/commit/4eb6161eeeb7c35647fe9dd230c5a2e4028614db) | `oneko: use xorg.* packages directly instead of xlibsWrapper indirection`             |
| [`c0eb1f38`](https://github.com/NixOS/nixpkgs/commit/c0eb1f38f821d75066fac0d335ba76fa3552d10e) | `netdiscover: 0.9 -> 0.10`                                                            |
| [`170c46ce`](https://github.com/NixOS/nixpkgs/commit/170c46ce2b75d67d7a98cc262b52f8155e9610e2) | `python310Packages.progressbar2: use pytestCheckHook`                                 |
| [`d654690b`](https://github.com/NixOS/nixpkgs/commit/d654690be5aee7d227d7426e92e167f7afe1d451) | `yq-go: 4.28.2 -> 4.29.1`                                                             |
| [`b91b2224`](https://github.com/NixOS/nixpkgs/commit/b91b22248c0479e74789ed9b94393ea84c3fe411) | `lima: 0.12.0 -> 0.13.0`                                                              |
| [`54cb67ac`](https://github.com/NixOS/nixpkgs/commit/54cb67ac972aebf45cf8bd6330d72fe6ba30fa38) | `python310Packages.motor: update disabled`                                            |
| [`ec02fca5`](https://github.com/NixOS/nixpkgs/commit/ec02fca53a70b069c5e708a7bdad6859e2c47f53) | `python310Packages.mss: disable on older Python releases`                             |
| [`d97c29dd`](https://github.com/NixOS/nixpkgs/commit/d97c29dd842cc0815b7536c8d78bd81b0b9c0dcb) | `notion: use xorg.* packages directly instead of xlibsWrapper indirection`            |
| [`e90683d7`](https://github.com/NixOS/nixpkgs/commit/e90683d79f50aa600e3e918273490497c8fce358) | `python310Packages.pulumi-aws: 5.18.0 -> 5.19.0`                                      |
| [`3c2305eb`](https://github.com/NixOS/nixpkgs/commit/3c2305ebc320840db33847db45a134118383211e) | `python310Packages.psygnal: 0.5.0 -> 0.6.0`                                           |
| [`c2e1495f`](https://github.com/NixOS/nixpkgs/commit/c2e1495fd7a0f88b84cdd83afeb0113e6d640df1) | `python310Packages.progressbar2: 4.1.1 -> 4.2.0`                                      |
| [`4fbac129`](https://github.com/NixOS/nixpkgs/commit/4fbac1297f16ed6a096ab982d99a33cd90ae3c07) | `qmmp: drop unused xlibsWrapper`                                                      |
| [`84510146`](https://github.com/NixOS/nixpkgs/commit/84510146d4420d0fb659263c89e05bf7f346d46e) | `terraform-providers.flexibleengine: 1.33.0 → 1.34.0`                                 |
| [`8eecb712`](https://github.com/NixOS/nixpkgs/commit/8eecb712e7f9f233e37e0f1f2e38370d18501916) | `python310Packages.panel: 0.14.0 -> 0.14.1`                                           |
| [`e81347c4`](https://github.com/NixOS/nixpkgs/commit/e81347c4ecd6924dcedb84cb8d7bef4d9f4d5d75) | `python310Packages.mss: 6.1.0 -> 7.0.1`                                               |
| [`0922d412`](https://github.com/NixOS/nixpkgs/commit/0922d4127e4ae165b127a6d1c599c94aa68707ba) | `packer: 1.8.3 -> 1.8.4`                                                              |
| [`2f74bf9c`](https://github.com/NixOS/nixpkgs/commit/2f74bf9ce86149f3094c86ee93d695864bad1b90) | `vhs: init at 0.1.1`                                                                  |
| [`c85289ae`](https://github.com/NixOS/nixpkgs/commit/c85289ae3bac9deb668c1a6f3154d6fbb6a64e76) | `oh-my-posh: 12.9.1 -> 12.10.0`                                                       |
| [`90781718`](https://github.com/NixOS/nixpkgs/commit/907817187980cedc9e048045276002379fd19063) | `python310Packages.motor: 3.1.0 -> 3.1.1`                                             |
| [`651e30bc`](https://github.com/NixOS/nixpkgs/commit/651e30bc43698df2117958d67df04e8b6df0ceff) | `python310Packages.meshtastic: 1.3.42 -> 1.3.43`                                      |
| [`610fcf12`](https://github.com/NixOS/nixpkgs/commit/610fcf1243fef570261c3255e8150b87b11c9604) | `nixos/mautrix-facebook: add new required config option`                              |
| [`e8119355`](https://github.com/NixOS/nixpkgs/commit/e8119355961b95db09c1bd9f590ee5bfba163783) | `python310Packages.aioswitcher: 3.1.0 -> 3.2.0`                                       |
| [`556082b2`](https://github.com/NixOS/nixpkgs/commit/556082b2f533f4b6dc0c308cf9c0a3d0a059af19) | `python310Packages.aionotion: update disabled`                                        |
| [`3171790b`](https://github.com/NixOS/nixpkgs/commit/3171790bc778180e5a1fc8f490300e9b3f42bc3b) | `python310Packages.aionotion: 2021.10.0 -> 2022.10.0`                                 |
| [`5b4f0e60`](https://github.com/NixOS/nixpkgs/commit/5b4f0e60911acadf5b69958aa8ce76e64750a922) | `python310Packages.md-toc: 8.1.4 -> 8.1.5`                                            |
| [`8f4dd2ca`](https://github.com/NixOS/nixpkgs/commit/8f4dd2cad1cf1299dbb0c6610685936ad76d0c57) | `python310Packages.shtab: 1.5.5 -> 1.5.6`                                             |
| [`38090aea`](https://github.com/NixOS/nixpkgs/commit/38090aea8938b320f8014831dee9b3aed7c28877) | `python310Packages.teamcity-messages: 1.31 -> 1.32`                                   |
| [`96596bec`](https://github.com/NixOS/nixpkgs/commit/96596bec5f0702870dc2f761743ff80799f13b3e) | `python310Packages.velbus-aio: 2022.10.3 -> 2022.10.4`                                |
| [`21e95fef`](https://github.com/NixOS/nixpkgs/commit/21e95fef889baf18bb64cea155726508defdc380) | `python310Packages.peaqevcore: 7.0.10 -> 7.0.13`                                      |
| [`c22386ca`](https://github.com/NixOS/nixpkgs/commit/c22386ca2a19cdc05c55497f7bd4643acfd34a20) | `python310Packages.aioguardian: 2022.07.0 -> 2022.10.0`                               |
| [`56703430`](https://github.com/NixOS/nixpkgs/commit/56703430700889a029a673e47ff042cf33072102) | `python310Packages.aioambient: 2021.12.0 -> 2022.10.0`                                |
| [`ea21be3c`](https://github.com/NixOS/nixpkgs/commit/ea21be3c67e758d5841f42c019d46e3439b7e935) | `python310Packages.aioridwell: 2022.03.0 -> 2022.10.0`                                |
| [`b517f679`](https://github.com/NixOS/nixpkgs/commit/b517f6794dbd7ff88c928f563cd585b9d4ecb960) | `python310Packages.aiorecollect: 2021.10.0 -> 2022.10.0`                              |
| [`bbab142a`](https://github.com/NixOS/nixpkgs/commit/bbab142a73b26cb38af1cd107078e73f4a4cf565) | `minio: 2022-10-24T18-35-07Z -> 2022-10-29T06-21-33Z`                                 |
| [`d4f4b726`](https://github.com/NixOS/nixpkgs/commit/d4f4b726076e0eff7bab350adfab64c6172e5b27) | `minio-client: 2022-10-22T03-39-29Z -> 2022-10-29T10-09-23Z`                          |
| [`32034da1`](https://github.com/NixOS/nixpkgs/commit/32034da16cc2050c5c8703c5c4a13d62507bd79f) | `python3Packages.enlighten: fix build`                                                |
| [`59d86922`](https://github.com/NixOS/nixpkgs/commit/59d86922551042eb9d722440ad20f214a8d9f4fa) | `pgf-umlsd: init at unstable-2020-05-28`                                              |
| [`92ed989f`](https://github.com/NixOS/nixpkgs/commit/92ed989f819c7999121eeb0528261fa223cb222f) | `pgf-umlcd: init at 0.3`                                                              |
| [`ad826d15`](https://github.com/NixOS/nixpkgs/commit/ad826d15b6e66d71b6b0bed7bc3cadb01d2e3d1b) | `python310Packages.nasdaq-data-link: init at 1.0.4`                                   |
| [`9c4d840c`](https://github.com/NixOS/nixpkgs/commit/9c4d840c7c10425c4bf811ffc9da49637f822a04) | `pgf-pie: init at 0.7`                                                                |
| [`1a821b62`](https://github.com/NixOS/nixpkgs/commit/1a821b629bfb71c69ab64459b9dbe65fa2e3da93) | `pgfplots: 1.5.1 -> 1.18.1`                                                           |
| [`782fca13`](https://github.com/NixOS/nixpkgs/commit/782fca13fe1090528eea2eec39bf76f975bc72fa) | `pgf-3.x: 3.0.0 -> 3.1.9a`                                                            |
| [`a2de5412`](https://github.com/NixOS/nixpkgs/commit/a2de5412daab3971a78bcc4fd06bc3437a23d9a6) | `pgf-2.x: 2.00 -> 2.10`                                                               |
| [`c482175b`](https://github.com/NixOS/nixpkgs/commit/c482175b033703b8ebfd38694db0a257164a6a12) | `pgf-1.x: use github source`                                                          |
| [`ea0f2f72`](https://github.com/NixOS/nixpkgs/commit/ea0f2f725084c2f29a976c06b5b9e3fcb1c01f7c) | `ligo: 0.54.0 -> 0.54.1`                                                              |
| [`9ca7aaff`](https://github.com/NixOS/nixpkgs/commit/9ca7aaffec4e33c30e23c5b7dcb945700203be5c) | `ruff: 0.0.88 -> 0.0.89`                                                              |
| [`888217b2`](https://github.com/NixOS/nixpkgs/commit/888217b295f36276b5182e7378612030a2dfe41d) | `python310Packages.pylast: 5.0.0 -> 5.1.0`                                            |
| [`b5533ca5`](https://github.com/NixOS/nixpkgs/commit/b5533ca5d69840cc40ddcfc9f440d3c11660ecc3) | `python310Packages.openapi-core: 0.14.2 -> 0.16.1`                                    |
| [`b647155e`](https://github.com/NixOS/nixpkgs/commit/b647155e5b0418d23a69281c6602cf063926e63c) | `mujoco: init at 2.3.0 (#198145)`                                                     |
| [`bffa58c9`](https://github.com/NixOS/nixpkgs/commit/bffa58c925da4ffb1b985e001c491737fc041f94) | `python310Packages.datasette-template-sql: disable tests`                             |
| [`16448f9e`](https://github.com/NixOS/nixpkgs/commit/16448f9e76cf207a331e397b33b3e059b81fce0d) | `doc: use evaluating instead of iterating`                                            |
| [`0c738e2e`](https://github.com/NixOS/nixpkgs/commit/0c738e2e1826e8347b32a5649bdae2ccb23f2a8a) | `doc: add code comment clarifying the meaning of legacyPackages`                      |
| [`7a191435`](https://github.com/NixOS/nixpkgs/commit/7a1914356e6ab0c0e8a7a4ba06ec891f78301281) | `patchelf_0_9: drop`                                                                  |
| [`b2f00c08`](https://github.com/NixOS/nixpkgs/commit/b2f00c08e525e8dcc30a7b97a72fa4c3ddb810dc) | `gallia: relax aiofiles constraint`                                                   |
| [`ee915716`](https://github.com/NixOS/nixpkgs/commit/ee91571678b3503c6ad39809e8eccc48673022ae) | `python310Packages.ultraheat-api: 0.5.0 -> 0.5.1`                                     |
| [`1cecfb54`](https://github.com/NixOS/nixpkgs/commit/1cecfb5488df12e96b313a4ef09c24a97da1c49a) | `audacity: build in release mode`                                                     |
| [`78b1a9a0`](https://github.com/NixOS/nixpkgs/commit/78b1a9a0da5d4952fc6b0599a18247aef90e60f1) | `xml2rfc: 3.15.0 -> 3.15.1`                                                           |
| [`527891ed`](https://github.com/NixOS/nixpkgs/commit/527891edec9f6639d814e06ccfa113bf946ad4bd) | `prowlarr: 0.4.6.1969 -> 0.4.7.2016`                                                  |
| [`0ea558b4`](https://github.com/NixOS/nixpkgs/commit/0ea558b4ff7f9b5d1cecef04513f92c79c5e6036) | `mame: 0.243 -> 0.249`                                                                |
| [`c3ac6ea4`](https://github.com/NixOS/nixpkgs/commit/c3ac6ea4ba33ce2a44069e9a97ff840df9995ad0) | `python310Packages.datasette: 0.61.1 -> 0.63`                                         |
| [`721d63b0`](https://github.com/NixOS/nixpkgs/commit/721d63b05c562a269fa4ffb92eb2848da26a62e6) | `unrar: 6.1.7 -> 6.2.1`                                                               |
| [`8fa4c2dc`](https://github.com/NixOS/nixpkgs/commit/8fa4c2dc477de9339082fd32c3315b448e732dce) | `vlc: use xorg.libSM packages directly instead of xlibsWrapper indirection`           |
| [`3a759f3b`](https://github.com/NixOS/nixpkgs/commit/3a759f3b6169457e59b774039df691e9cc391fd9) | `python310Packages.aiomysensors: 0.3.0 -> 0.3.1`                                      |
| [`c532303b`](https://github.com/NixOS/nixpkgs/commit/c532303ba1559618ead8b9ce3296daeebcef7968) | `python310Packages.aiofiles: 0.8.0 -> 22.1.0`                                         |
| [`c6f62266`](https://github.com/NixOS/nixpkgs/commit/c6f6226649940bf515abf5f65163efe25faadb61) | `pulumi-bin: 3.44.1 -> 3.44.3`                                                        |
| [`7c0282c3`](https://github.com/NixOS/nixpkgs/commit/7c0282c39694242c671ffae088edb841b4601ca9) | `ecs-agent: 1.65.0 -> 1.65.1`                                                         |
| [`e4dfd09d`](https://github.com/NixOS/nixpkgs/commit/e4dfd09d34006e997dac5e035715a0391cae1411) | `pgadmin4: 6.14 -> 6.15`                                                              |
| [`915165d3`](https://github.com/NixOS/nixpkgs/commit/915165d37966f88e87dbf58401058a707ae3f3ae) | `phpPackages.composer: 2.4.2 -> 2.4.4`                                                |
| [`b36ccc2b`](https://github.com/NixOS/nixpkgs/commit/b36ccc2bb689cca324bce40c748559b7dd3f5f23) | `python310Packages.aiolifx: 0.8.6 -> 0.8.7`                                           |
| [`248ad2f5`](https://github.com/NixOS/nixpkgs/commit/248ad2f5ca9724cf50b80e2f5f1afbeddddfb973) | `python3Packages.pywlroots: 0.15.22 -> 0.15.24`                                       |
| [`8b44356e`](https://github.com/NixOS/nixpkgs/commit/8b44356e1f6a41df69f543dac7c7c9bfae8ff939) | `cinnamon.cinnamon-common: unbreak cinnamon2d session`                                |
| [`68eea648`](https://github.com/NixOS/nixpkgs/commit/68eea64825d516d388434ad83dcf955ba5f601f6) | `xidlehook: use xorg.* packages directly instead of xlibsWrapper indirection`         |
| [`fa269d4e`](https://github.com/NixOS/nixpkgs/commit/fa269d4e0d2a8f48f10605878ef91314bec325c9) | `doc/rl-2211: add new option overrideStrategy`                                        |
| [`918c8525`](https://github.com/NixOS/nixpkgs/commit/918c8525c14522474678e255c6ac54fe9619910a) | `checkip: 0.42.0 -> 0.42.1`                                                           |
| [`4db4ddf0`](https://github.com/NixOS/nixpkgs/commit/4db4ddf01aebc7ff14ccd3086d3c5b514f2c2a50) | `cbmc: 5.69.0 -> 5.69.1`                                                              |
| [`f80a0993`](https://github.com/NixOS/nixpkgs/commit/f80a0993d0355c9314b545cff9dac135a60153ca) | `paper-note: fix moved dependencies to buildinputs`                                   |
| [`1887b5e0`](https://github.com/NixOS/nixpkgs/commit/1887b5e04867dda539a6a7ba7b9bddb6f747c647) | `paper-note: fix, file now editorconfig compliant`                                    |
| [`04debedb`](https://github.com/NixOS/nixpkgs/commit/04debedbb12453830af4db2915cd7a259b99998c) | `paper-note: refactor, removed redundant nativeBuildInputs`                           |
| [`1272ac7a`](https://github.com/NixOS/nixpkgs/commit/1272ac7a524db6f7aac1332c82f9e8b664f365cb) | `paper-note: refactor build deps, symlink`                                            |
| [`83494d58`](https://github.com/NixOS/nixpkgs/commit/83494d5854fb44b56b2625fa940d3405ee11f68e) | `roslyn: update dependencies`                                                         |
| [`6e279e44`](https://github.com/NixOS/nixpkgs/commit/6e279e44c260b761bdaff782927a88f5fc272c70) | `dotnet-sdk_5: 5.0.403 -> 5.0.408`                                                    |
| [`6758f450`](https://github.com/NixOS/nixpkgs/commit/6758f450df458e3c4b62e501ec4b432a6472d0e7) | `all-packages.nix: reorder TeX toolsets`                                              |
| [`e99b23f5`](https://github.com/NixOS/nixpkgs/commit/e99b23f56274216ea9e19c48822a8405624101a0) | `brev-cli: 0.6.146 -> 0.6.148`                                                        |
| [`2c3a2ac7`](https://github.com/NixOS/nixpkgs/commit/2c3a2ac7e2ce9bc4bc830e5ce53d27ae5059aae2) | `dotnet-sdk: properly copy license files.`                                            |
| [`28c21c14`](https://github.com/NixOS/nixpkgs/commit/28c21c140a563bf66f394999c296c22f621cf26e) | `vscodium: 1.72.2.22286 -> 1.72.2.22289`                                              |
| [`2a321282`](https://github.com/NixOS/nixpkgs/commit/2a32128294582578bfd780f085523b6124f09cec) | `liferea: 1.14-RC1 -> 1.14-RC2`                                                       |
| [`929ec07e`](https://github.com/NixOS/nixpkgs/commit/929ec07ef5d5cff779fd9bb0e30fff65d7d98f3e) | `jackett: 0.20.2171 -> 0.20.2175`                                                     |
| [`784c363b`](https://github.com/NixOS/nixpkgs/commit/784c363bd0fad7249e793c808e3883ff59d936ab) | `retroarch: use libretro-core-info, simplify patch`                                   |
| [`3cc1d6ef`](https://github.com/NixOS/nixpkgs/commit/3cc1d6efb34b597194d2258f4b9ac4a53c882fc7) | `vmagent: 1.82.1 -> 1.83.0`                                                           |
| [`8d616c18`](https://github.com/NixOS/nixpkgs/commit/8d616c189ba0999bbedc1325bbd7bfe732743bb6) | `vscode-extensions.mkhl.direnv: 0.6.1 -> 0.7.0`                                       |
| [`6f0cbc0d`](https://github.com/NixOS/nixpkgs/commit/6f0cbc0dbf9baa74634428a6561968d7f7540662) | `vscode-extensions.catppuccin.catppuccin-vsc: 2.1.0 -> 2.2.1`                         |
| [`3d0ad187`](https://github.com/NixOS/nixpkgs/commit/3d0ad187479b81a9df3dee394e3d04954f13e05b) | `glances: 3.2.7 -> 3.3.0`                                                             |
| [`789d6ffb`](https://github.com/NixOS/nixpkgs/commit/789d6ffbd93071e76b4a794dd7bb1e68fea2ec81) | `libnvidia-container: remove go from closure`                                         |
| [`711bc5f8`](https://github.com/NixOS/nixpkgs/commit/711bc5f86c903da6ba6934cba0aa585725d95ba6) | `zoom: use xorg.* packages directly instead of xlibsWrapper indirection`              |
| [`ebe6f518`](https://github.com/NixOS/nixpkgs/commit/ebe6f5184996ba7f30776acf1b32ba729082ecd1) | `xxgdb: use xorg.* packages directly instead of xlibsWrapper indirection`             |
| [`0b67da19`](https://github.com/NixOS/nixpkgs/commit/0b67da19dfe24bb982965619d92d4ed73a69e0af) | `xwinwrap: use xorg.* packages directly instead of xlibsWrapper indirection`          |
| [`e180a698`](https://github.com/NixOS/nixpkgs/commit/e180a6988a85a323aab0060528bcbff6baddb426) | `xtrlock-pam: use xorg.* packages directly instead of xlibsWrapper indirection`       |
| [`75633a59`](https://github.com/NixOS/nixpkgs/commit/75633a59b1d26d41fd306487548f00c6afbcc7a8) | `xspim: use xorg.* packages directly instead of xlibsWrapper indirection`             |
| [`ac36151f`](https://github.com/NixOS/nixpkgs/commit/ac36151fcbb8d28219a1262512c8d2d1529b59d5) | `xmountains: use xorg.* packages directly instead of xlibsWrapper indirection`        |
| [`032fd5c0`](https://github.com/NixOS/nixpkgs/commit/032fd5c0c2029778eed079862b9373d8fcf94194) | `xinput_calibrator: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`c9f4e679`](https://github.com/NixOS/nixpkgs/commit/c9f4e679cc004fbbcd9fb40045f1a5fc4db23eff) | `xine-ui: drop unused xlibsWrapper`                                                   |
| [`6a179efd`](https://github.com/NixOS/nixpkgs/commit/6a179efd12605e3b101497a11d906e957df77a22) | `xfig: drop unused xlibsWrapper`                                                      |
| [`ede66124`](https://github.com/NixOS/nixpkgs/commit/ede661244e4869499e83f5317c11a6f98e89bdac) | `ted: use xorg.* packages directly instead of xlibsWrapper indirection`               |
| [`e6471b1a`](https://github.com/NixOS/nixpkgs/commit/e6471b1a0e233aaf9750e42d73fecbb2c139f928) | `scrot: use xorg.* packages directly instead of xlibsWrapper indirection`             |
| [`ecf6426a`](https://github.com/NixOS/nixpkgs/commit/ecf6426a2dba715af9814f9aad60c2a6ad883e9c) | `diffoscope: 224 -> 225`                                                              |
| [`cfb60e72`](https://github.com/NixOS/nixpkgs/commit/cfb60e72b962bf51eb66050cf894c27dad9442b2) | `python310Packages.pyeight: 0.3.1 -> 0.3.2`                                           |
| [`0311fe1f`](https://github.com/NixOS/nixpkgs/commit/0311fe1f62b4d2e0b37869349b084fe485b95379) | `home-assistant: update component-packages`                                           |
| [`f30a2b7d`](https://github.com/NixOS/nixpkgs/commit/f30a2b7de92ea26930a9037f295f5b875dde4e68) | `python310Packages.pyswitchbee: init at 1.6.0`                                        |
| [`ead38268`](https://github.com/NixOS/nixpkgs/commit/ead382681efee646ee446a8ef73cd85ef33bbfac) | `miniupnpd: 2.1.20190502 -> 2.3.1`                                                    |
| [`7cce48d5`](https://github.com/NixOS/nixpkgs/commit/7cce48d5970c234072b2d35113ce3368625fd64e) | `miniupnpc_2: 2.1.20190625 -> 2.2.4`                                                  |
| [`e2f0896e`](https://github.com/NixOS/nixpkgs/commit/e2f0896eb9156a7b109b7c4ca29ad78a3068ddce) | `toast: init at 0.45.5`                                                               |
| [`325aabe6`](https://github.com/NixOS/nixpkgs/commit/325aabe637dbf738b65572626c6f88c6d8ce28f8) | `python310Packages.pg8000: 1.29.2 -> 1.29.3`                                          |
| [`c9711faf`](https://github.com/NixOS/nixpkgs/commit/c9711faf63ab9cfd9d8ec12dc1815c1b3a280f86) | `python310Packages.scramp: 1.4.1 -> 1.4.3`                                            |
| [`8b2b03db`](https://github.com/NixOS/nixpkgs/commit/8b2b03db27fc5697e19b81c6130ba3849e380e6d) | `mmlgui: unstable-2022-09-15 -> unstable-2022-10-13`                                  |
| [`ca26446b`](https://github.com/NixOS/nixpkgs/commit/ca26446b328a3c91084f17a198c6b55831b7535b) | `symfony-cli: 5.4.16 -> 5.4.17`                                                       |
| [`e9098a84`](https://github.com/NixOS/nixpkgs/commit/e9098a84085ce1aedd6f2b2534621dd2dbb45d1c) | `awscli2: 2.8.6 -> 2.8.7`                                                             |
| [`08c4eb31`](https://github.com/NixOS/nixpkgs/commit/08c4eb3143c7b9205e06d6b1c69c886189ccf3be) | `python3Packages.geopandas: 0.12.0 → 0.12.1`                                          |
| [`a5385801`](https://github.com/NixOS/nixpkgs/commit/a53858010b576291eda47035fbaa77ab40bf33c7) | `nixos/zfs: introduce option to control hibernation`                                  |
| [`acfbf03f`](https://github.com/NixOS/nixpkgs/commit/acfbf03f328de554b612129e9680de3b686c6381) | `python310Packages.phonenumbers: 8.12.56 -> 8.12.57`                                  |
| [`eff84319`](https://github.com/NixOS/nixpkgs/commit/eff84319752d334c82df2812b9bd219e79babdbf) | `python310Packages.awscrt: update disabled`                                           |