### PR TITLE
chore(flake/pre-commit): `078b0dee` -> `471c7f1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1669152228,
-        "narHash": "sha256-FEDReoTLWJHXcNso7aaAlAUU7uOqIR6Hc/C/nqlfooE=",
+        "lastModified": 1669829516,
+        "narHash": "sha256-laWMD/TZzyrulu8xLNoSPertXOxjRD7BrcAVwKl+NyQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "078b0dee35e2da01334af682ec347463b70a9986",
+        "rev": "471c7f1ecace25e39099206431300322632d25c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`5c36747c`](https://github.com/cachix/pre-commit-hooks.nix/commit/5c36747c631083f45984cce3e8bf411183e25ada) | `Add Prettier output option`   |
| [`923e4f1f`](https://github.com/cachix/pre-commit-hooks.nix/commit/923e4f1ffde27765c562870735d3c679b8b4f2b6) | `Add typos`                    |
| [`0d780870`](https://github.com/cachix/pre-commit-hooks.nix/commit/0d7808709c6de0247106ea199d4d2a1d0039572c) | `default.nix: expose packages` |