### PR TITLE
chore(flake/crane): `0428181b` -> `98894bb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1669853699,
-        "narHash": "sha256-SvyPRwJeET7PCifBOvu+reQUUlyc4Ya1K37GrtZyiXY=",
+        "lastModified": 1672095661,
+        "narHash": "sha256-7NTsdCn3qsvU7A+1/7tY8pxbq0DYy1pFYNpzN6he9lI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0428181b7b8f619e71095cf2fab051bccdf10041",
+        "rev": "98894bb39b03bfb379c5e10523cd61160e1ac782",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667487142,
-        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
+        "lastModified": 1670034122,
+        "narHash": "sha256-EqmuOKucPWtMvCZtHraHr3Q3bgVszq1x2PoZtQkUuEk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
+        "rev": "a0d5773275ecd4f141d792d3a0376277c0fc0b65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`98894bb3`](https://github.com/ipetkov/crane/commit/98894bb39b03bfb379c5e10523cd61160e1ac782) | `Update CHANGELOG`                                                            |
| [`755e604b`](https://github.com/ipetkov/crane/commit/755e604b79efa0c83959e5be06276aa6165759ed) | `book: fix references`                                                        |
| [`55a143e9`](https://github.com/ipetkov/crane/commit/55a143e9a8d0a8c997293ab0f706075aa0154882) | `book: add CNAME`                                                             |
| [`a4d70a26`](https://github.com/ipetkov/crane/commit/a4d70a26e78801128057a00238205c4c6fde0f7f) | `Add Crane book (#199)`                                                       |
| [`67b1799c`](https://github.com/ipetkov/crane/commit/67b1799c335f6aeff44e90c5ee463cbd93287bb1) | `README: add a comment about setting pname`                                   |
| [`eae8252b`](https://github.com/ipetkov/crane/commit/eae8252b68472863d83814c9165a513687cd319c) | `README: add FAQ about building workspace subsets (#198)`                     |
| [`8b66edc0`](https://github.com/ipetkov/crane/commit/8b66edc016237c696a4a02ff8e0840b554174d59) | `mkDummySource: fix build invalidation regression (#195)`                     |
| [`70fcce8d`](https://github.com/ipetkov/crane/commit/70fcce8db07c5121b02c2f1484768a3cff59edac) | `mkDummySrc: try to use the same output name as original source (#190)`       |
| [`59b31b41`](https://github.com/ipetkov/crane/commit/59b31b41a589c0a65e4a1f86b0e5eac68081468b) | `Add buildInputs to quick-start doc (#185)`                                   |
| [`63f80ee2`](https://github.com/ipetkov/crane/commit/63f80ee278897e72a1468090278716b5befa5128) | `zstd: use as many threads as we can when compressing (#183)`                 |
| [`2243fb9c`](https://github.com/ipetkov/crane/commit/2243fb9c872de25cb564a02d324ea6a5b9853052) | `Update flake.lock (#181)`                                                    |
| [`ea271bdc`](https://github.com/ipetkov/crane/commit/ea271bdc05810171a52548c4ae28d4823c09d34e) | `ci: test against 22.11 and stop testing 22.05 (#179)`                        |
| [`fb80a689`](https://github.com/ipetkov/crane/commit/fb80a689c5c517bc40d9cc1828c384c38de90dda) | `Update CHANGELOG`                                                            |
| [`ed59895b`](https://github.com/ipetkov/crane/commit/ed59895b7ae2ee3ba28d81f9961cb720072cfc04) | `chore(deps): bump DeterminateSystems/update-flake-lock from 14 to 15 (#178)` |