### PR TITLE
chore(flake/rust): `3158e47f` -> `176b6fd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669775522,
-        "narHash": "sha256-6xxGArBqssX38DdHpDoPcPvB/e79uXyQBwpBcaO/BwY=",
+        "lastModified": 1672453260,
+        "narHash": "sha256-ruR2xo30Vn7kY2hAgg2Z2xrCvNePxck6mgR5a8u+zow=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3158e47f6b85a288d12948aeb9a048e0ed4434d6",
+        "rev": "176b6fd3dd3d7cea8d22ab1131364a050228d94c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message     |
| ----------------------------------------------------------------------------------------------------- | ------------------ |
| [`176b6fd3`](https://github.com/oxalica/rust-overlay/commit/176b6fd3dd3d7cea8d22ab1131364a050228d94c) | `manifest: update` |
| [`e6b22143`](https://github.com/oxalica/rust-overlay/commit/e6b2214363f5e18576a3b2ca0e0483d8f42fe531) | `manifest: update` |
| [`ede97767`](https://github.com/oxalica/rust-overlay/commit/ede977678e5d0164316998487e686d0790744cd7) | `manifest: update` |
| [`bb9fef79`](https://github.com/oxalica/rust-overlay/commit/bb9fef79d831cc3c1bfdda2bb72e69706d1ab168) | `manifest: update` |
| [`f4827ef0`](https://github.com/oxalica/rust-overlay/commit/f4827ef0518463f31a52ab2e5c500c80558fdd78) | `manifest: update` |
| [`33d196f9`](https://github.com/oxalica/rust-overlay/commit/33d196f944676bdbd1965f5bf436b8b8d4ea4e5f) | `manifest: update` |
| [`fd274031`](https://github.com/oxalica/rust-overlay/commit/fd2740316bacb3e0106381c325e0bb90d6790aeb) | `manifest: update` |
| [`631e6921`](https://github.com/oxalica/rust-overlay/commit/631e692192eeeea85cdfb2a9dccbbfce543478b1) | `manifest: update` |
| [`03ec5d9b`](https://github.com/oxalica/rust-overlay/commit/03ec5d9bff7dda3fba01fb8ab4b6381e57543ad2) | `manifest: update` |
| [`225c0b73`](https://github.com/oxalica/rust-overlay/commit/225c0b73534b7ead914c89fcb86c8de3df66eb15) | `manifest: update` |
| [`bfc54bcf`](https://github.com/oxalica/rust-overlay/commit/bfc54bcf98dacdc649c88a82bf14d00b399aa3bb) | `manifest: update` |
| [`e4e129cf`](https://github.com/oxalica/rust-overlay/commit/e4e129cf743b49b663d99abe81142d6bd213ac91) | `manifest: update` |
| [`fbaaff24`](https://github.com/oxalica/rust-overlay/commit/fbaaff24f375ac25ec64268b0a0d63f91e474b7d) | `manifest: update` |
| [`31f0276d`](https://github.com/oxalica/rust-overlay/commit/31f0276dd8bc0dff576394a985e89be4a4995b4e) | `manifest: update` |
| [`905db211`](https://github.com/oxalica/rust-overlay/commit/905db21103d646ddc1eb81920e05180e6e2b6734) | `manifest: update` |
| [`7da2f6b3`](https://github.com/oxalica/rust-overlay/commit/7da2f6b3a0c32f661cb2864d7fbd1d7e6f0c7543) | `manifest: update` |
| [`684659b7`](https://github.com/oxalica/rust-overlay/commit/684659b7ca903e512a421bc6ade689fb26e509b4) | `manifest: update` |
| [`da99b622`](https://github.com/oxalica/rust-overlay/commit/da99b6227d450438d53ba4b0cf64e43ad2e93e58) | `manifest: update` |
| [`f0bcb23e`](https://github.com/oxalica/rust-overlay/commit/f0bcb23e31033ab31639e6a1d85c44ce6ccaa335) | `manifest: update` |
| [`fe185fac`](https://github.com/oxalica/rust-overlay/commit/fe185fac76e009b4bd543704a8c61077cf70155b) | `manifest: update` |
| [`0dcfaaf2`](https://github.com/oxalica/rust-overlay/commit/0dcfaaf2b1e2b00f3fa3ce9d4019508fbc12d93e) | `manifest: update` |
| [`d00c488c`](https://github.com/oxalica/rust-overlay/commit/d00c488cb455c21fea731167bf8c1b8da605aac3) | `manifest: update` |
| [`a0fdafd1`](https://github.com/oxalica/rust-overlay/commit/a0fdafd18c9cf599fde17fbaf07dbb20fa57eecb) | `manifest: update` |
| [`073959f0`](https://github.com/oxalica/rust-overlay/commit/073959f0687277a54bfaa3ac7a77feb072f88186) | `manifest: update` |
| [`fc98242f`](https://github.com/oxalica/rust-overlay/commit/fc98242f5f49d39b8fd3a611c146741a35dc012d) | `manifest: update` |
| [`9767af96`](https://github.com/oxalica/rust-overlay/commit/9767af967a0becaa3bb79eeda838dbf81295eb62) | `manifest: update` |
| [`18823e51`](https://github.com/oxalica/rust-overlay/commit/18823e511bc85ed27bfabe33cccecb389f9aa92d) | `manifest: update` |
| [`eca2f757`](https://github.com/oxalica/rust-overlay/commit/eca2f757838f162bbe000443fc5f02b6993774e1) | `manifest: update` |
| [`a0d57732`](https://github.com/oxalica/rust-overlay/commit/a0d5773275ecd4f141d792d3a0376277c0fc0b65) | `manifest: update` |
| [`3d506453`](https://github.com/oxalica/rust-overlay/commit/3d506453ce9c510b12e8dd98781bfaa2ea436772) | `manifest: update` |
| [`bfdf6887`](https://github.com/oxalica/rust-overlay/commit/bfdf688742cf984c4837dbbe1c6cbca550365613) | `manifest: update` |