### PR TITLE
chore(flake/pre-commit): `471c7f1e` -> `67d98f02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1668984258,
-        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "lastModified": 1671271954,
+        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1669829516,
-        "narHash": "sha256-laWMD/TZzyrulu8xLNoSPertXOxjRD7BrcAVwKl+NyQ=",
+        "lastModified": 1672050129,
+        "narHash": "sha256-GBQMcvJUSwAVOpDjVKzB6D5mmHI7Y4nFw+04bnS9QrM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "471c7f1ecace25e39099206431300322632d25c4",
+        "rev": "67d98f02443b9928bc77f1267741dcfdd3d7b65c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                               |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`1d71c50b`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d71c50b9daa2d1ce0a6439d9c004066c3f84f10) | `Add phpcs and phpcbf hooks`                 |
| [`200790e9`](https://github.com/cachix/pre-commit-hooks.nix/commit/200790e9c77064c53eaf95805b013d96615ecc27) | `reduce closure size`                        |
| [`74966fec`](https://github.com/cachix/pre-commit-hooks.nix/commit/74966fec0b7f5d137ebe9897f32db94360fd3d5b) | `bump deps`                                  |
| [`9174d2c4`](https://github.com/cachix/pre-commit-hooks.nix/commit/9174d2c47a21b10374f47de227248e1d43a4dda9) | `add php-cs-fixer as hook`                   |
| [`0be586c2`](https://github.com/cachix/pre-commit-hooks.nix/commit/0be586c2f28600a06819aa4144436883112bce1d) | `Haskell formatters: Include .hs-boot files` |
| [`1320a5eb`](https://github.com/cachix/pre-commit-hooks.nix/commit/1320a5eb4b0f3bbb65f1d022ee9de55576f5d85d) | `Fix clang-format types`                     |
| [`5f7721dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/5f7721ddc71ba9fce55186100d27d041310785ea) | `Disable Commitizen build tests`             |
| [`49ffc6f9`](https://github.com/cachix/pre-commit-hooks.nix/commit/49ffc6f976de18792ec73f3af5a5c7bd54a555b6) | `Add Commitizen`                             |
| [`e4411607`](https://github.com/cachix/pre-commit-hooks.nix/commit/e44116074b57ac1be2f4334313f4ef414d022fa5) | `Add flake8`                                 |
| [`c218cba0`](https://github.com/cachix/pre-commit-hooks.nix/commit/c218cba04b375d63c52a9ae33b3a32a238b6630b) | `Add Pylint`                                 |
| [`1879f0db`](https://github.com/cachix/pre-commit-hooks.nix/commit/1879f0db6c50225dea0125e4f845366ed0dbb717) | `Add editorconfig-checker`                   |
| [`fced41b0`](https://github.com/cachix/pre-commit-hooks.nix/commit/fced41b07b9a77133d366db28430f3b18c2e8e45) | `Fix Prettier output option`                 |