### PR TITLE
chore(flake/pre-commit): `67d98f02` -> `ce4efeec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -127,11 +127,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1672050129,
-        "narHash": "sha256-GBQMcvJUSwAVOpDjVKzB6D5mmHI7Y4nFw+04bnS9QrM=",
+        "lastModified": 1675169698,
+        "narHash": "sha256-C1wFiyJ+4SRvIsFkdMIN1Fa+58APmyTGKWpX9EKOehM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "67d98f02443b9928bc77f1267741dcfdd3d7b65c",
+        "rev": "ce4efeec34c6eb35ba07b8fceaae87d6b46c1c5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                        |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`3973f374`](https://github.com/cachix/pre-commit-hooks.nix/commit/3973f374042c9c6dc80d39e7a6805242256608ad) | `fix: allow .git directory on parent directory`       |
| [`a6cf19ab`](https://github.com/cachix/pre-commit-hooks.nix/commit/a6cf19ab7da60a9b0025b53b2e035489bcdb15cf) | `feat: add settings to yamlint`                       |
| [`a7751f68`](https://github.com/cachix/pre-commit-hooks.nix/commit/a7751f682687a8388d007a15499b202e8234d367) | `Fix Ruff backward compatibility`                     |
| [`a486c79f`](https://github.com/cachix/pre-commit-hooks.nix/commit/a486c79f675e186ec35a22f1375018dc46c68415) | `feat: add autoflake`                                 |
| [`ffe68508`](https://github.com/cachix/pre-commit-hooks.nix/commit/ffe68508c7e17b1d2a2a11a56fb4d743edcda6c9) | `Reorder ruff arg`                                    |
| [`677c994b`](https://github.com/cachix/pre-commit-hooks.nix/commit/677c994b4a91e20bcbd009f354109af101e70ed4) | `Fix missing ruff`                                    |
| [`7abd9af7`](https://github.com/cachix/pre-commit-hooks.nix/commit/7abd9af70dcbf8d3d5b6ffe9143ccdb788716ebb) | `Update modules/hooks.nix`                            |
| [`fffce9e8`](https://github.com/cachix/pre-commit-hooks.nix/commit/fffce9e8c6f6bc0c7ffa171b5609792329b7140d) | `Update modules/hooks.nix`                            |
| [`e5e17563`](https://github.com/cachix/pre-commit-hooks.nix/commit/e5e175632dece2b7a7773b837d1f540fc8a6b568) | `Add Ruff`                                            |
| [`3e42a775`](https://github.com/cachix/pre-commit-hooks.nix/commit/3e42a77571cc0463efa470dbcffa063977a521ab) | `README: mention first-class integration into devenv` |
| [`ebff638f`](https://github.com/cachix/pre-commit-hooks.nix/commit/ebff638f3b6f89ab3eb98eaab7a9fda7b65c5198) | `revert nixpkgs-unstable bump and cleanup`            |
| [`2904e3d9`](https://github.com/cachix/pre-commit-hooks.nix/commit/2904e3d90f092209c4ba59530703496ecc83942e) | `remove nix-linter as it's unmaintained`              |
| [`40185412`](https://github.com/cachix/pre-commit-hooks.nix/commit/401854129b442c3999f8616353ed7827614d808f) | `brittany: remove as it's deprecated`                 |
| [`6beacee6`](https://github.com/cachix/pre-commit-hooks.nix/commit/6beacee69601abb32ae0cb038f701cffc527dec7) | `nixos: 22.05 -> 22.11`                               |
| [`80a549b7`](https://github.com/cachix/pre-commit-hooks.nix/commit/80a549b7947459b3bc613e60dfc3ff7814bc855b) | `Fix flake8 binary path option default text`          |
| [`72b2c3d6`](https://github.com/cachix/pre-commit-hooks.nix/commit/72b2c3d6a7bda32af4a2941f82c2a8401a94d15e) | `feat: add bats checker`                              |
| [`592e629c`](https://github.com/cachix/pre-commit-hooks.nix/commit/592e629ccb6ca0a37d6ae684fee70fb111590608) | `Stop go hooks being enabled by default`              |
| [`4924de75`](https://github.com/cachix/pre-commit-hooks.nix/commit/4924de75039937f316146a7e66df74080498b544) | `refact: add mkCmdArgs function`                      |
| [`6671dda1`](https://github.com/cachix/pre-commit-hooks.nix/commit/6671dda1325fc5df06a4bdc61cf5b2430a5e8827) | `feat: add new golang hooks`                          |
| [`11c6d36a`](https://github.com/cachix/pre-commit-hooks.nix/commit/11c6d36ab00a67ad02c8a9b2e06568c69cc9cedd) | `Add option to fail when clippy emits warnings`       |
| [`55f5732b`](https://github.com/cachix/pre-commit-hooks.nix/commit/55f5732b5391f87ed1e5e6aa82ce09c37a242ebe) | `yamllint: Add relaxed option`                        |
| [`69dacb5a`](https://github.com/cachix/pre-commit-hooks.nix/commit/69dacb5aae76938dc2a94fc090bdd3cb61cbb198) | `docs: add actionlint`                                |
| [`9e8d1738`](https://github.com/cachix/pre-commit-hooks.nix/commit/9e8d17382dae1bcf68f4cf3ad08fbd04048e87d3) | `Allow to configure path to Cargo.toml`               |