### PR TITLE
chore(flake/crane): `98894bb3` -> `ccea7b33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1672095661,
-        "narHash": "sha256-7NTsdCn3qsvU7A+1/7tY8pxbq0DYy1pFYNpzN6he9lI=",
+        "lastModified": 1674348649,
+        "narHash": "sha256-hBRlaUlsrmW1wAPevwQnkrT0XiLrmlAHWabWYmLeQlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "98894bb39b03bfb379c5e10523cd61160e1ac782",
+        "rev": "ccea7b33178daf6010aae3ea2b3fb5b0241b9146",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670034122,
-        "narHash": "sha256-EqmuOKucPWtMvCZtHraHr3Q3bgVszq1x2PoZtQkUuEk=",
+        "lastModified": 1672712534,
+        "narHash": "sha256-8S0DdMPcbITnlOu0uA81mTo3hgX84wK8S9wS34HEFY4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0d5773275ecd4f141d792d3a0376277c0fc0b65",
+        "rev": "69fb7bf0a8c40e6c4c197fa1816773774c8ac59f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`ccea7b33`](https://github.com/ipetkov/crane/commit/ccea7b33178daf6010aae3ea2b3fb5b0241b9146) | `Update CHANGELOG`                                                                     |
| [`a41a7d3f`](https://github.com/ipetkov/crane/commit/a41a7d3f81bbc698a22c0deaae76ace759dbd9bd) | `Update docs to clarify buildPackage installation behavior (#225)`                     |
| [`00564437`](https://github.com/ipetkov/crane/commit/00564437f30e2a5b448448c7b0d500a69506d02b) | `Properly handle workspace inheritance in git dependencies (#224)`                     |
| [`b13963c8`](https://github.com/ipetkov/crane/commit/b13963c8c18026aa694acd98d14f66d24666f70b) | `chore: bump some git deps in Cargo.locks (#221)`                                      |
| [`01441343`](https://github.com/ipetkov/crane/commit/0144134311767fcee80213321f079a8ffa0b9cc1) | `chore: bump all Cargo.locks (#219)`                                                   |
| [`ea3a8139`](https://github.com/ipetkov/crane/commit/ea3a813939842e21e99b5b26a078db4e086d341b) | `examples: add cross-windows (#218)`                                                   |
| [`da51c587`](https://github.com/ipetkov/crane/commit/da51c5871231d820d50e2bbef2e4311926cf516e) | `chore(deps): bump tokio from 1.18.0 to 1.24.1 in /examples/cross-rust-overlay (#217)` |
| [`cb0c042a`](https://github.com/ipetkov/crane/commit/cb0c042a274cf531e80567dcff720f321e03eb63) | `docs: make example code for nested workspaces more universal (#215)`                  |
| [`472617f6`](https://github.com/ipetkov/crane/commit/472617f66cec1dd805e3c391c75e999d296502f2) | `Update PR template`                                                                   |
| [`6e7e5361`](https://github.com/ipetkov/crane/commit/6e7e53616b6decfe23e116efce7781c3deed1335) | `docs: fix example for sandbox unfriendly dependency workaround (#214)`                |
| [`42e2fab6`](https://github.com/ipetkov/crane/commit/42e2fab6bc3dcbeea9d557c4eba2508e50abea18) | `Make it easier to build workspaces not at source root (#212)`                         |
| [`dfe3afcd`](https://github.com/ipetkov/crane/commit/dfe3afcdd934d9d804a52724b8b55474ddd79ee5) | `Update docs (#211)`                                                                   |
| [`ec10516a`](https://github.com/ipetkov/crane/commit/ec10516aadb705a20b043088072a556e3cb95253) | `Update flake.lock (#208)`                                                             |
| [`cc20f29b`](https://github.com/ipetkov/crane/commit/cc20f29b4ae0d4c6e13e01f08b2d9072b09b04e7) | `ci: pass GITHUB_TOKEN as an access token in more places`                              |
| [`18ef99b1`](https://github.com/ipetkov/crane/commit/18ef99b1e0e033f2f9f09798642e146be81afb80) | `inheritCargoArtifactsHook: preserve executable bit of build scripts (#206)`           |