### PR TITLE
chore(flake/rust): `176b6fd3` -> `48b14031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672453260,
-        "narHash": "sha256-ruR2xo30Vn7kY2hAgg2Z2xrCvNePxck6mgR5a8u+zow=",
+        "lastModified": 1675132198,
+        "narHash": "sha256-izOVjdIfdv0OzcfO9rXX0lfGkQn4tdJ0eNm3P3LYo/o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "176b6fd3dd3d7cea8d22ab1131364a050228d94c",
+        "rev": "48b1403150c3f5a9aeee8bc4c77c8926f29c6501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`48b14031`](https://github.com/oxalica/rust-overlay/commit/48b1403150c3f5a9aeee8bc4c77c8926f29c6501) | `manifest: update`                         |
| [`7093dfcd`](https://github.com/oxalica/rust-overlay/commit/7093dfcd21df83026ee20426af80bf2072e2da92) | `manifest: update`                         |
| [`edd082ca`](https://github.com/oxalica/rust-overlay/commit/edd082ca16aa055d5504bea39da36b3ee68e4f1d) | `manifest: update`                         |
| [`bbc57d7a`](https://github.com/oxalica/rust-overlay/commit/bbc57d7aac4ac1ec0a68ff77a22d03622cc11246) | `manifest: update`                         |
| [`296dd673`](https://github.com/oxalica/rust-overlay/commit/296dd673b46aaebe1c8355f1848ceb7c905dda35) | `manifest: update`                         |
| [`480f9cc3`](https://github.com/oxalica/rust-overlay/commit/480f9cc37db841d1fd3ac0b0c059d48e5eb6946c) | `manifest: update`                         |
| [`187b7835`](https://github.com/oxalica/rust-overlay/commit/187b7835d59b9c040e0782b5b129de113207c2d5) | `manifest: update`                         |
| [`57b363f3`](https://github.com/oxalica/rust-overlay/commit/57b363f390f031b8b8d26235c2d21b0ad5a84640) | `manifest: update`                         |
| [`a16fb5f0`](https://github.com/oxalica/rust-overlay/commit/a16fb5f08d16e33727c8303dabefd81f06cb64c7) | `manifest: update`                         |
| [`1fd6d280`](https://github.com/oxalica/rust-overlay/commit/1fd6d280c132f4facad8cd023543fb10121e6487) | `manifest: update`                         |
| [`bf982fca`](https://github.com/oxalica/rust-overlay/commit/bf982fcabe4f1c62fb99094ee06af8cade0fe399) | `manifest: update`                         |
| [`5f7315b9`](https://github.com/oxalica/rust-overlay/commit/5f7315b9800e2e500e6834767a57e39f7dbfd495) | `manifest: update`                         |
| [`eecc4493`](https://github.com/oxalica/rust-overlay/commit/eecc44934a0f6c02c02856b38bd3b6af3bec0870) | `manifest: update`                         |
| [`4e0f9b8a`](https://github.com/oxalica/rust-overlay/commit/4e0f9b8a5102387f8d19901bced16a256a6ccdc7) | `manifest: update`                         |
| [`8f201a1a`](https://github.com/oxalica/rust-overlay/commit/8f201a1adfddf715b708befd18164c8cbe65a268) | `manifest: update`                         |
| [`aab6eb2d`](https://github.com/oxalica/rust-overlay/commit/aab6eb2dfc7a1e42d94b6f24ef13639ff8544af4) | `manifest: update`                         |
| [`90163bbb`](https://github.com/oxalica/rust-overlay/commit/90163bbbadce526f8b248a5fe545b06c59597108) | `manifest: update`                         |
| [`ca474ccd`](https://github.com/oxalica/rust-overlay/commit/ca474ccdd5f81ed742328e15dae38bb57a1006e3) | `manifest: update`                         |
| [`0833f4d0`](https://github.com/oxalica/rust-overlay/commit/0833f4d063a2bb75aa31680f703ba594a384ffe6) | `manifest: update`                         |
| [`a979c85e`](https://github.com/oxalica/rust-overlay/commit/a979c85ed4691bf996af88504522b32e9611ccfe) | `manifest: update`                         |
| [`9724998e`](https://github.com/oxalica/rust-overlay/commit/9724998ea2caf23214674bf0c2cdf6ec0b1719af) | `manifest: update`                         |
| [`3488cec0`](https://github.com/oxalica/rust-overlay/commit/3488cec01351c2f1086b02a3a61808be7a25103e) | `manifest: update`                         |
| [`07c10018`](https://github.com/oxalica/rust-overlay/commit/07c10018a48b637d9864030468679adaeb18ab95) | `manifest: update`                         |
| [`802ff331`](https://github.com/oxalica/rust-overlay/commit/802ff3314663ec7114f29a6e8b200dfc892023f8) | `manifest: update`                         |
| [`9096306d`](https://github.com/oxalica/rust-overlay/commit/9096306d4a1c3adcc8d20f2c9dcaee3dee30d1ad) | `manifest: update`                         |
| [`1be785a7`](https://github.com/oxalica/rust-overlay/commit/1be785a7a3e9f3ac669d80befbe671cf96f6aae4) | `manifest: update`                         |
| [`746b57a0`](https://github.com/oxalica/rust-overlay/commit/746b57a0ad71ae5b9ed863868c5c8a56d3382213) | `Try to fix CI`                            |
| [`d5d48d20`](https://github.com/oxalica/rust-overlay/commit/d5d48d20d35152030ea44613dc3945b69f3fb23a) | `Add rustc dependency for rustfmt`         |
| [`b56371ee`](https://github.com/oxalica/rust-overlay/commit/b56371eeeb8e028baee9fee019682b28556e6c1c) | `Drop old channels from CI and fix README` |
| [`fdaad2a9`](https://github.com/oxalica/rust-overlay/commit/fdaad2a9526217d5bdde4868653f068c7b8201ad) | `manifest: update`                         |
| [`44651039`](https://github.com/oxalica/rust-overlay/commit/44651039608da372ce70b936c5db1ea372b7b03e) | `Use GitHub token for API requests`        |
| [`69fb7bf0`](https://github.com/oxalica/rust-overlay/commit/69fb7bf0a8c40e6c4c197fa1816773774c8ac59f) | `manifest: update`                         |
| [`c8bf9c16`](https://github.com/oxalica/rust-overlay/commit/c8bf9c162bb3f734cf357846e995eb70b94e2bcd) | `manifest: update`                         |
| [`f17584a6`](https://github.com/oxalica/rust-overlay/commit/f17584a6e8f1f26b8d4606fa35d529466a015dc8) | `manifest: update`                         |