### PR TITLE
chore(flake/pre-commit): `ce4efeec` -> `29dbe1ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675169698,
-        "narHash": "sha256-C1wFiyJ+4SRvIsFkdMIN1Fa+58APmyTGKWpX9EKOehM=",
+        "lastModified": 1680170909,
+        "narHash": "sha256-FtKU/edv1jFRr/KwUxWTYWXEyj9g8GBrHntC2o8oFI8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ce4efeec34c6eb35ba07b8fceaae87d6b46c1c5f",
+        "rev": "29dbe1efaa91c3a415d8b45d62d48325a4748816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`30d1c34b`](https://github.com/cachix/pre-commit-hooks.nix/commit/30d1c34bdbfe3dd0b8fbdde3962180c56cf16f12) | `` add treefmt ``                                                        |
| [`eced2275`](https://github.com/cachix/pre-commit-hooks.nix/commit/eced227562737ab18435e72a10aac8dfe092d4b3) | `` nil: fix issue with multiple files ``                                 |
| [`1045ae05`](https://github.com/cachix/pre-commit-hooks.nix/commit/1045ae059bc179b8f0997ec932a01c9441c3239a) | `` [bump] bump dependencies ``                                           |
| [`ad0d326b`](https://github.com/cachix/pre-commit-hooks.nix/commit/ad0d326b2a1a1a0876a8312d4a2c6232c49ca3b1) | `` Add tagref to README.md ``                                            |
| [`fb032377`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb032377d74c904904743f41dbbd63856fefdc4b) | `` Add nil hook ``                                                       |
| [`fd2babcd`](https://github.com/cachix/pre-commit-hooks.nix/commit/fd2babcdb4906ed8a46259b452bbf2cf78dd6176) | `` tagref hook ``                                                        |
| [`e55944c6`](https://github.com/cachix/pre-commit-hooks.nix/commit/e55944c68fc60ef23859fc403f68e07392824628) | `` Add mypy support ``                                                   |
| [`f3ec38af`](https://github.com/cachix/pre-commit-hooks.nix/commit/f3ec38af440d08447929c62e8eed6426c04dd676) | `` chore(deps): bump cachix/install-nix-action from 19 to 20 ``          |
| [`f15232b7`](https://github.com/cachix/pre-commit-hooks.nix/commit/f15232b739b4f9c684991f1a50aef10e5d93fa3b) | `` options: add fail_fast and require_serial ``                          |
| [`ca42ec27`](https://github.com/cachix/pre-commit-hooks.nix/commit/ca42ec27cd5085063e712fc087730d35e60b1d5a) | `` [fix] do not try to access the internet when running cargo clippy ``  |
| [`d71e3d75`](https://github.com/cachix/pre-commit-hooks.nix/commit/d71e3d75ec0cc37d180238bfddd79b79ef02f177) | `` [feat] change usage of direnv to using nix-direnv instead of lorri `` |
| [`6b678da4`](https://github.com/cachix/pre-commit-hooks.nix/commit/6b678da4433ec0396de04da0c7026ce159b9449f) | `` add zprint ``                                                         |
| [`071c0ebe`](https://github.com/cachix/pre-commit-hooks.nix/commit/071c0ebed5c2b89b16090fea8d909084c2ad25fd) | `` latexindent: fix unknown command line option ``                       |
| [`d3b49e72`](https://github.com/cachix/pre-commit-hooks.nix/commit/d3b49e724549b7a83ae06d37f60a43998f02f453) | `` Add LaTeX pre-commit hooks to README ``                               |
| [`1e29fe23`](https://github.com/cachix/pre-commit-hooks.nix/commit/1e29fe23a76ccc3a54dcc7526127992737c7c6b2) | `` Add luacheck to README ``                                             |
| [`6727e1dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/6727e1dd751125a59a60dd017f2649aa497c585c) | `` Add taplo fmt ``                                                      |
| [`2df88654`](https://github.com/cachix/pre-commit-hooks.nix/commit/2df88654ab016e36fbe99018dc2768a2256cfff5) | `` chore(deps): bump cachix/install-nix-action from 18 to 19 ``          |
| [`ab608394`](https://github.com/cachix/pre-commit-hooks.nix/commit/ab608394886fb04b8a5df3cb0bab2598400e3634) | `` get rid of automatic rebasing ``                                      |
| [`dc1c6013`](https://github.com/cachix/pre-commit-hooks.nix/commit/dc1c60138d190fecb08e306dda19ae1851194ba0) | `` Typo ``                                                               |
| [`4a7e21d5`](https://github.com/cachix/pre-commit-hooks.nix/commit/4a7e21d5a9fa7a4a5fc4c13d8dfcbaefccbea147) | `` Add a `dune/opam sync` hook ``                                        |
| [`9c637c9f`](https://github.com/cachix/pre-commit-hooks.nix/commit/9c637c9fe4d993c0ad77fa9658826273368140c6) | `` Add an `ocp-indent` hook ``                                           |
| [`57dd8898`](https://github.com/cachix/pre-commit-hooks.nix/commit/57dd88987b6b78a5013b7956fdcfc866ba69758b) | `` Mention `opam-lint` hook in README ``                                 |
| [`ee2ee47b`](https://github.com/cachix/pre-commit-hooks.nix/commit/ee2ee47bd77b98576ecea31c528d385c7a377ea1) | `` Add `opam lint` hook ``                                               |
| [`45cc6627`](https://github.com/cachix/pre-commit-hooks.nix/commit/45cc6627190b9c045aebc7e933f284a5d25bfb99) | `` Rewrite `hpack-dir`; include fixes and doc ``                         |
| [`9d8f7902`](https://github.com/cachix/pre-commit-hooks.nix/commit/9d8f79029d4d781442498c1734839e55604ba91c) | `` Fix `files` pattern for `hpack` ``                                    |