### PR TITLE
chore(flake/rust): `48b14031` -> `aa480d79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675132198,
-        "narHash": "sha256-izOVjdIfdv0OzcfO9rXX0lfGkQn4tdJ0eNm3P3LYo/o=",
+        "lastModified": 1680229280,
+        "narHash": "sha256-9UoyQCeKUmHcsIdpsAgcz41LAIDkWhI2PhVDjckrpg0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "48b1403150c3f5a9aeee8bc4c77c8926f29c6501",
+        "rev": "aa480d799023141e1b9e5d6108700de63d9ad002",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`aa480d79`](https://github.com/oxalica/rust-overlay/commit/aa480d799023141e1b9e5d6108700de63d9ad002) | `` manifest: update ``                   |
| [`f20680ef`](https://github.com/oxalica/rust-overlay/commit/f20680efa5faf2b7aa164e8f8bc0e69e5be5e8de) | `` manifest: update ``                   |
| [`c8d8d05b`](https://github.com/oxalica/rust-overlay/commit/c8d8d05b8100d451243b614d950fa3f966c1fcc2) | `` manifest: update ``                   |
| [`26ef1a20`](https://github.com/oxalica/rust-overlay/commit/26ef1a2029239e204e51ab3402f8aae5aa1187ed) | `` manifest: update ``                   |
| [`898c5b2e`](https://github.com/oxalica/rust-overlay/commit/898c5b2e11a1bcdf056573f9b1cdf920c5ae4ed2) | `` manifest: update ``                   |
| [`7f38143d`](https://github.com/oxalica/rust-overlay/commit/7f38143d19432a0f9780197febe3fac9d3b0773a) | `` manifest: update ``                   |
| [`8ba8bdae`](https://github.com/oxalica/rust-overlay/commit/8ba8bdaee0dfb4b7ad8b1f398e4f24d4dee89760) | `` manifest: update ``                   |
| [`afbdcf30`](https://github.com/oxalica/rust-overlay/commit/afbdcf305fd6f05f708fe76d52f24d37d066c251) | `` manifest: update ``                   |
| [`fbc7ae3f`](https://github.com/oxalica/rust-overlay/commit/fbc7ae3f14d32e78c0e8d7865f865cc28a46b232) | `` manifest: update ``                   |
| [`a89d328c`](https://github.com/oxalica/rust-overlay/commit/a89d328ca7d106c3fdbbd072b6c7088ab5b798a3) | `` manifest: update ``                   |
| [`f5efdf14`](https://github.com/oxalica/rust-overlay/commit/f5efdf14ed378aac26cadded4d0c00ca91974d32) | `` manifest: update ``                   |
| [`c680a0a4`](https://github.com/oxalica/rust-overlay/commit/c680a0a4144bb0931f6cebd601a3978bbafc4f64) | `` manifest: update ``                   |
| [`32e4b1bf`](https://github.com/oxalica/rust-overlay/commit/32e4b1bf80cf99b7c72d2892198d40558828e6a1) | `` manifest: update ``                   |
| [`7313c06a`](https://github.com/oxalica/rust-overlay/commit/7313c06ac334d6262ddfe30a38b3abc3da6bd565) | `` manifest: update ``                   |
| [`41872ef6`](https://github.com/oxalica/rust-overlay/commit/41872ef6ee3d14236c345a5c528d679533e045dd) | `` manifest: update ``                   |
| [`5c1af9b9`](https://github.com/oxalica/rust-overlay/commit/5c1af9b9d618e02a87cdd30a3022aec0b78cd9aa) | `` manifest: update ``                   |
| [`35f8293d`](https://github.com/oxalica/rust-overlay/commit/35f8293d6e58d14c6255d40be7bed3389d08701a) | `` manifest: update ``                   |
| [`d907affe`](https://github.com/oxalica/rust-overlay/commit/d907affef544f64bd6886fe6bcc5fa2495a82373) | `` manifest: update ``                   |
| [`f25d4bc2`](https://github.com/oxalica/rust-overlay/commit/f25d4bc2f6a0a3f9a2f15d3b9e3edb0ee5099a3d) | `` manifest: update ``                   |
| [`2ffce3e9`](https://github.com/oxalica/rust-overlay/commit/2ffce3e9c3da6c756a7862c7de2f6f9813c02aba) | `` manifest: update ``                   |
| [`1c8200cd`](https://github.com/oxalica/rust-overlay/commit/1c8200cdc4c830d937fbf8b19e1f3e83daf3370a) | `` manifest: update ``                   |
| [`9f687941`](https://github.com/oxalica/rust-overlay/commit/9f687941160108f89dd8bd2c650d32c15a35c7c7) | `` manifest: update ``                   |
| [`bdf08e2f`](https://github.com/oxalica/rust-overlay/commit/bdf08e2f43488283eeb25b4a7e7ecba9147a955c) | `` manifest: update ``                   |
| [`cb22476a`](https://github.com/oxalica/rust-overlay/commit/cb22476a4d0e0b8b21900d220c2b1cf830821f9d) | `` manifest: update ``                   |
| [`ea311f10`](https://github.com/oxalica/rust-overlay/commit/ea311f10a5d51e7588799281bab0556b4e978d00) | `` manifest: update ``                   |
| [`423b16be`](https://github.com/oxalica/rust-overlay/commit/423b16bef17c9e8e9ea515e502c0c5d0f8e51f4a) | `` manifest: update ``                   |
| [`695b8bb0`](https://github.com/oxalica/rust-overlay/commit/695b8bb0af23d4ad3826fe7a372a5d677ad5c2bd) | `` manifest: update ``                   |
| [`1a9f6285`](https://github.com/oxalica/rust-overlay/commit/1a9f6285d441ff438a6a1422dc3fde109d8615bf) | `` manifest: update ``                   |
| [`c25d3e19`](https://github.com/oxalica/rust-overlay/commit/c25d3e1951863ac0061d47a3fabf9aa7c91db5e5) | `` manifest: update ``                   |
| [`e53e8853`](https://github.com/oxalica/rust-overlay/commit/e53e8853aa7b0688bc270e9e6a681d22e01cf299) | `` manifest: update ``                   |
| [`0449a5a3`](https://github.com/oxalica/rust-overlay/commit/0449a5a382fbb91faedcbd9d51e1a2f5e863efb2) | `` manifest: update ``                   |
| [`f388187e`](https://github.com/oxalica/rust-overlay/commit/f388187efb41ce4195b2f4de0b6bb463d3cd0a76) | `` manifest: update ``                   |
| [`c1df023b`](https://github.com/oxalica/rust-overlay/commit/c1df023b1aaded1b65a1f4ad604a98a58ab4db97) | `` manifest: update ``                   |
| [`2924bfce`](https://github.com/oxalica/rust-overlay/commit/2924bfce2fadc1ded4a2b8cfce7f2fd4ef41c36f) | `` manifest: update ``                   |
| [`603d1da9`](https://github.com/oxalica/rust-overlay/commit/603d1da90298cd5746731f58899fd1bdde9afcfb) | `` manifest: update ``                   |
| [`34cdbf6a`](https://github.com/oxalica/rust-overlay/commit/34cdbf6ad480ce13a6a526f57d8b9e609f3d65dc) | `` manifest: update ``                   |
| [`b91706f9`](https://github.com/oxalica/rust-overlay/commit/b91706f9d5a68fecf97b63753da8e9670dff782b) | `` manifest: update ``                   |
| [`c67c79ea`](https://github.com/oxalica/rust-overlay/commit/c67c79ea25664d66e74ae91a6fa0d6c65d12d3a7) | `` manifest: update ``                   |
| [`6c9e8ea3`](https://github.com/oxalica/rust-overlay/commit/6c9e8ea3ba73a9fed29ddc1cc52ade8e5c946a8d) | `` manifest: update ``                   |
| [`f02d590b`](https://github.com/oxalica/rust-overlay/commit/f02d590b871a6241dc55d41e799bc530e28214ce) | `` manifest: update ``                   |
| [`98f11700`](https://github.com/oxalica/rust-overlay/commit/98f11700e398cf2ae6da905df56badc17e265021) | `` manifest: update ``                   |
| [`a6fa4239`](https://github.com/oxalica/rust-overlay/commit/a6fa42390d46ef1326fbe98288b65d3b586870da) | `` manifest: update ``                   |
| [`bdccd5e9`](https://github.com/oxalica/rust-overlay/commit/bdccd5e973d45159f7d13f7c65a4271dc02cf6d4) | `` manifest: update ``                   |
| [`d0dc81ff`](https://github.com/oxalica/rust-overlay/commit/d0dc81ffe8ea09dbf3c07db62a1a057f5319e3ce) | `` manifest: update ``                   |
| [`3bab7ae4`](https://github.com/oxalica/rust-overlay/commit/3bab7ae4a80de02377005d611dc4b0a13082aa7c) | `` manifest: update ``                   |
| [`a6195386`](https://github.com/oxalica/rust-overlay/commit/a619538647bd03e3ee1d7b947f7c11ff289b376e) | `` Fix typo in cross_compilation docs `` |
| [`ac9c38d3`](https://github.com/oxalica/rust-overlay/commit/ac9c38d335804933e2ba7a24eb13713732251f1f) | `` manifest: update ``                   |
| [`956ddb50`](https://github.com/oxalica/rust-overlay/commit/956ddb5047f98ea08b792b22004b94a9971932c4) | `` manifest: update ``                   |
| [`1bd5d7bb`](https://github.com/oxalica/rust-overlay/commit/1bd5d7bb2f31cbc43fb8f722e3a39a45ee4dcec8) | `` manifest: update ``                   |
| [`ef4cd733`](https://github.com/oxalica/rust-overlay/commit/ef4cd733dc6b595cab5092f5004a489c5fd80b07) | `` manifest: update ``                   |
| [`1373567f`](https://github.com/oxalica/rust-overlay/commit/1373567ffd13719f6b7522737b010bfc514d49b4) | `` manifest: update ``                   |
| [`9cfdc72e`](https://github.com/oxalica/rust-overlay/commit/9cfdc72e60fde874819045b563fc1523dc99afe0) | `` manifest: update ``                   |
| [`50ee0fa4`](https://github.com/oxalica/rust-overlay/commit/50ee0fa4d0eeadd97c63be57e14b01d531e79ed7) | `` manifest: update ``                   |
| [`02e1abbd`](https://github.com/oxalica/rust-overlay/commit/02e1abbdcbc2d516193ff8a7add71f44cd976ba0) | `` manifest: update ``                   |
| [`fce84890`](https://github.com/oxalica/rust-overlay/commit/fce84890519f05703e4b1f4c70bf9bb118206ffd) | `` manifest: update ``                   |
| [`cccf15dc`](https://github.com/oxalica/rust-overlay/commit/cccf15dce049eb0be24060ed461c251552b2fb4d) | `` manifest: update ``                   |
| [`3bf0a253`](https://github.com/oxalica/rust-overlay/commit/3bf0a253c07b4ddea8a5f0fb805e2a412cc7c7d4) | `` manifest: update ``                   |
| [`1f1d1384`](https://github.com/oxalica/rust-overlay/commit/1f1d13846ae88826391e5d65d85247a30982671b) | `` manifest: update ``                   |
| [`383a4acf`](https://github.com/oxalica/rust-overlay/commit/383a4acfd11d778d5c2efcf28376cbd845eeaedf) | `` manifest: update ``                   |
| [`61ec735a`](https://github.com/oxalica/rust-overlay/commit/61ec735acfb1f549237bc525da355bd0b9cc70a3) | `` manifest: update ``                   |
| [`b86e0944`](https://github.com/oxalica/rust-overlay/commit/b86e094432c5576867b75a2834babf06aafd6c49) | `` manifest: update ``                   |