### PR TITLE
chore(flake/nixpkgs): `2caf4ef5` -> `e3652e07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675115703,
-        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`4d0c1a91`](https://github.com/NixOS/nixpkgs/commit/4d0c1a9157eb313e40b5447193ffe44b909d13c4) | `` coder: mark as broken + refactoring ``                                   |
| [`701f8d5f`](https://github.com/NixOS/nixpkgs/commit/701f8d5f6d67a3dd3db7091ca59c0274839a60a0) | `` terraform: add completion ``                                             |
| [`21d1721f`](https://github.com/NixOS/nixpkgs/commit/21d1721fd42b484432983ad5d6db9c60c6d062fd) | `` lagrange: 1.15.6 → 1.15.7 ``                                             |
| [`539ba8ea`](https://github.com/NixOS/nixpkgs/commit/539ba8eaf8ea96eb2ca2398e98aba2317fe07bff) | `` vscode: 1.76.2 -> 1.77 ``                                                |
| [`ee5fe4a9`](https://github.com/NixOS/nixpkgs/commit/ee5fe4a9c83825f66240aa624dcb5ea43b2a76a5) | `` vscode-extensions.github.vscode-pull-request-github: switch to stable `` |
| [`954f9b0f`](https://github.com/NixOS/nixpkgs/commit/954f9b0ff40323d66db81facc553f752b9124f0b) | `` rocm-thunk: 5.4.3 -> 5.4.4 ``                                            |
| [`463643af`](https://github.com/NixOS/nixpkgs/commit/463643afa8b70b153ef1728493afce53817514ff) | `` coqPackages.HoTT: 8.16 -> 8.17 ``                                        |
| [`4c580b01`](https://github.com/NixOS/nixpkgs/commit/4c580b0107ebc58eebd8c44920ea18558ae73384) | `` visidata: fix #202165, add shell completions (#223894) ``                |
| [`4b1f9bc6`](https://github.com/NixOS/nixpkgs/commit/4b1f9bc616805e8ef365b00b8ac9d1059ef0523c) | `` shell_gpt: enable darwin ``                                              |
| [`005fbeb9`](https://github.com/NixOS/nixpkgs/commit/005fbeb9725b91de2b4b0750d87669220b985fa7) | `` python310Packages.formulaic: checkInputs -> nativeCheckInputs ``         |
| [`1649bf34`](https://github.com/NixOS/nixpkgs/commit/1649bf34c4fd496e3e07631b00b8bb93ddb55e08) | `` python310Packages.ttach: checkInputs -> nativeCheckInputs ``             |
| [`b5a14020`](https://github.com/NixOS/nixpkgs/commit/b5a140204398947562b7d5fb873a57da37fcb900) | `` python310Packages.dicom-numpy: checkInputs -> nativeCheckInputs ``       |
| [`0b724428`](https://github.com/NixOS/nixpkgs/commit/0b7244283970fa238480de5946ca6f025f129540) | `` python310Packages.siuba: checkInputs -> nativeCheckInputs ``             |
| [`526dddcf`](https://github.com/NixOS/nixpkgs/commit/526dddcfe96f1983de27be6eb92bc336fbc39ad0) | `` obs-studio-plugins.obs-vkcapture: 1.3.0 -> 1.3.1 ``                      |
| [`7dbc8be8`](https://github.com/NixOS/nixpkgs/commit/7dbc8be85931371f00c6da7daa13defa41008469) | `` python3Packages.gymnasium: init at 0.28.1 ``                             |
| [`8f8a5959`](https://github.com/NixOS/nixpkgs/commit/8f8a5959cced15a23aef1f388d3b74d205dbfa80) | `` python3Packages.jax-jumpy: init at 1.0.0 ``                              |
| [`5fc99ba4`](https://github.com/NixOS/nixpkgs/commit/5fc99ba499641463a6e953e7029b143358ecdf8b) | `` python3Packages.farama-notifications: init at 0.0.4 ``                   |
| [`62a3b644`](https://github.com/NixOS/nixpkgs/commit/62a3b6448f41f3d07eec6b32ef232b87caf54e14) | `` Revert "symlinkjoin: print warning when keeping existing file" ``        |
| [`5f6b338f`](https://github.com/NixOS/nixpkgs/commit/5f6b338fb04b092b76714af770705077ee58bdd0) | `` harmonia: 0.2.0 -> 0.6.0 ``                                              |
| [`ddf1b8ea`](https://github.com/NixOS/nixpkgs/commit/ddf1b8ea0b3602e518bce88f471bbfbab1a81627) | `` linuxKernel.kernels.linux_lqx: 6.2.7-lqx1 -> 6.2.9-lqx1 ``               |
| [`33beddf7`](https://github.com/NixOS/nixpkgs/commit/33beddf7cb8191cdf3ff50b20777c98f37a337c5) | `` linuxKernel.kernels.linux_zen: 6.2.7-zen1 -> 6.2.9-zen1 ``               |
| [`da5ce0a6`](https://github.com/NixOS/nixpkgs/commit/da5ce0a6962469d8df7e737f891b58fe7b3e720c) | `` tblite: fix python module ``                                             |
| [`f1937c17`](https://github.com/NixOS/nixpkgs/commit/f1937c174924a37b076cf9894d276cbb59ee41c6) | `` multicharge: fix pkg-config ``                                           |
| [`d86d2e7f`](https://github.com/NixOS/nixpkgs/commit/d86d2e7f5a64bd1306a0aadf1be4318429220117) | `` simple-dftd3: fix pkg-config ``                                          |
| [`15be8180`](https://github.com/NixOS/nixpkgs/commit/15be8180f5d1bac57771f39731e3f57d79665388) | `` mstore: fix pkg-config ``                                                |
| [`cc6d1e7f`](https://github.com/NixOS/nixpkgs/commit/cc6d1e7f346d5440540866a5347e43fa6ab03215) | `` mctc-lib: fix pkg-config ``                                              |
| [`5c30108f`](https://github.com/NixOS/nixpkgs/commit/5c30108f5e9857fb76098b9aa4f9ae7583321aa9) | `` dftd4: fix pkg-config ``                                                 |
| [`fcd1a1a2`](https://github.com/NixOS/nixpkgs/commit/fcd1a1a2e93d201d407aafeae1cc7d1099eee298) | `` python3Packages.django-ckeditor: init at 6.5.1 ``                        |
| [`8b8fa7cd`](https://github.com/NixOS/nixpkgs/commit/8b8fa7cd6d81b89e47b70b8e7f90f36398e2f648) | `` dapr-cli: Use correct licence (mit -> asl20) ``                          |
| [`bbc94f60`](https://github.com/NixOS/nixpkgs/commit/bbc94f60727d5abad1668f04725bc5a575e27e29) | `` maintainers/bigzilla: update information ``                              |
| [`f13bb7ef`](https://github.com/NixOS/nixpkgs/commit/f13bb7efd2b6eefb3bb8b62b3159f888f0264985) | `` liquidsoap: 2.1.3 -> 2.1.4 ``                                            |
| [`c95d302a`](https://github.com/NixOS/nixpkgs/commit/c95d302aa0ca3511b6e1fca2f9110ceb5f7f8387) | `` ocamlPackages.mm: 0.8.2 -> 0.8.3 ``                                      |
| [`a51fb98f`](https://github.com/NixOS/nixpkgs/commit/a51fb98f7347cfc1cca6902a24afbcfee75dad3e) | `` kaniko: remove superherointj as maintainer ``                            |
| [`1f087c36`](https://github.com/NixOS/nixpkgs/commit/1f087c364ac340c5d9db05ebdabc0bde62e07364) | `` ponyc: remove superherointj as maintainer ``                             |
| [`1dd67980`](https://github.com/NixOS/nixpkgs/commit/1dd679809775efc8bebd64aae1fc9e01e4e08fd3) | `` pony-corral: remove superherointj as maintainer ``                       |
| [`20c9e196`](https://github.com/NixOS/nixpkgs/commit/20c9e1965ad6c08784ad40390f76a5bd049bae55) | `` SDL2: remove superherointj as maintainer ``                              |
| [`446d8070`](https://github.com/NixOS/nixpkgs/commit/446d80702725d27284dd1797e7e3f63a54383ba5) | `` CODEOWNERS: remove superherointj ``                                      |
| [`3bee32d4`](https://github.com/NixOS/nixpkgs/commit/3bee32d49d3264d3d5d4fc8fc30cd973a35bfd42) | `` nerdfix: 0.1.0 -> 0.2.0 ``                                               |
| [`f8f3eb7a`](https://github.com/NixOS/nixpkgs/commit/f8f3eb7a480827ac1995a203c13dd96f6951ee35) | `` nixos/loki: add `package` option ``                                      |
| [`2fb10783`](https://github.com/NixOS/nixpkgs/commit/2fb1078369e96946c4da3baff226a558c127bc78) | `` Put mathcomp packages in alphabetical order ``                           |
| [`25c631cc`](https://github.com/NixOS/nixpkgs/commit/25c631cc0e529066726ddbfbfc5e1ccfe7218dee) | `` Add coqPackages.mathcomp-apery ``                                        |
| [`479b3864`](https://github.com/NixOS/nixpkgs/commit/479b38649ac031de89b162f4caa31ac5754be19d) | `` cypress: Remove test ``                                                  |
| [`9ebbbb4f`](https://github.com/NixOS/nixpkgs/commit/9ebbbb4fc0cd1653036752bc52430231141e337e) | `` Pleroma: use libxcrypt-legacy ``                                         |
| [`a94d9447`](https://github.com/NixOS/nixpkgs/commit/a94d9447ef7396751e0cd798d20743d02a820909) | `` llvmPackages_rocm.llvm: mark as broken on aarch64-linux ``               |
| [`ee797066`](https://github.com/NixOS/nixpkgs/commit/ee79706632dd716505280b7f551572b0eaa4d47a) | `` python310Packages.pandas-stubs: 1.5.3.230214 -> 1.5.3.230321 ``          |
| [`a1804709`](https://github.com/NixOS/nixpkgs/commit/a180470959d4a9a1d42da590c2bd252d0ef6bf56) | `` nixos/k3s: start after network-online ``                                 |
| [`486e3211`](https://github.com/NixOS/nixpkgs/commit/486e3211dc047cb1fec97ee6f9ae67b36a84522b) | `` python310Packages.mkdocs-jupyter: 0.22.0 -> 0.24.1 ``                    |
| [`1fb7326f`](https://github.com/NixOS/nixpkgs/commit/1fb7326f59b92e21013c31dd9a3ae034dec88be0) | `` python310Packages.mkdocs-jupyter: add changelog to meta ``               |
| [`540441db`](https://github.com/NixOS/nixpkgs/commit/540441dbc3c3b760263106fb6137ad9877c7ca9b) | `` python310Packages.ypy-websocket: relax aiofiles constraint ``            |
| [`cfefae7e`](https://github.com/NixOS/nixpkgs/commit/cfefae7ee6e6b40dcc1bfe4c8d86fb4388667860) | `` yutto: 2.0.0b20 -> 2.0.0b21 ``                                           |
| [`056509be`](https://github.com/NixOS/nixpkgs/commit/056509befe0f0b199a54f3c51b44be24a6d1b0ec) | `` gns3-server: migrate to pythonRelaxDepsHook ``                           |
| [`f79252ab`](https://github.com/NixOS/nixpkgs/commit/f79252abc3eb82b49e3f1de4720891a629e24b1f) | `` python310Packages.slowapi: switch to pythonRelaxDepsHook ``              |
| [`2c1f99f3`](https://github.com/NixOS/nixpkgs/commit/2c1f99f38e01102cedcc0e4c01a6d1cb7a37e1b1) | `` gallia: relax aiofiles constraint ``                                     |
| [`527a8e6e`](https://github.com/NixOS/nixpkgs/commit/527a8e6eede3985478f4c002f6acf049c2820e84) | `` river-luatile: 0.1.1 -> 0.1.2 ``                                         |
| [`1084cae7`](https://github.com/NixOS/nixpkgs/commit/1084cae74997b42f90c205f1ecbee23f9aa3439f) | `` python310Packages.aiofiles: update disabled ``                           |
| [`38921dcb`](https://github.com/NixOS/nixpkgs/commit/38921dcb59c7c42897840cfdc8374163e6fa7a7e) | `` python310Packages.aiomysensors: 0.3.6 -> 0.3.9 ``                        |
| [`ca352354`](https://github.com/NixOS/nixpkgs/commit/ca352354ed2acc700118ec249955a3fc26ba7533) | `` python310Packages.aiofiles: 22.1.0 -> 23.1.0 ``                          |
| [`3556a065`](https://github.com/NixOS/nixpkgs/commit/3556a065d5f0f25be330ae486970e186868f1bf4) | `` python310Packages.aiomysensors: add changelog to meta ``                 |
| [`15c944c3`](https://github.com/NixOS/nixpkgs/commit/15c944c31d629b8afb8813f97e90074f166bfe28) | `` python310Packages.aliyun-python-sdk-cdn: 3.8.3 -> 3.8.5 ``               |
| [`f89354c1`](https://github.com/NixOS/nixpkgs/commit/f89354c12f9824c764036887d0fef905c26a81af) | `` coqPackages_8_13.VST: fix by using compatible version of ITree ``        |
| [`8332da68`](https://github.com/NixOS/nixpkgs/commit/8332da68cb4eb843bc1daf2bf3ce6b015afaf833) | `` python310Packages.peaqevcore: 13.4.2 -> 13.4.5 ``                        |
| [`942c79ad`](https://github.com/NixOS/nixpkgs/commit/942c79adc7edee72e4c13f4af6d8ee3936aa12cb) | `` python310Packages.reolink-aio: 0.5.7 -> 0.5.8 ``                         |
| [`cf468472`](https://github.com/NixOS/nixpkgs/commit/cf4684729e1e9d3a88af6ba63664f1a8afde07fa) | `` python310Packages.pyswitchbot: 0.37.4 -> 0.37.5 ``                       |
| [`efd77d0b`](https://github.com/NixOS/nixpkgs/commit/efd77d0bc5756e9f3065c3fea9847d1de00027dc) | `` cppreference-doc: refactor, fix version ``                               |
| [`f118df5c`](https://github.com/NixOS/nixpkgs/commit/f118df5ce2d4c1561ca631115b139d0265294ad7) | `` python310Packages.iceportal: init at 1.1.1 ``                            |
| [`0324f56a`](https://github.com/NixOS/nixpkgs/commit/0324f56ae35b9e27153fc94f79989aad0fff0553) | `` cri-o: 1.26.2 -> 1.26.3 ``                                               |
| [`0063dc9e`](https://github.com/NixOS/nixpkgs/commit/0063dc9ef41243130114f5381304b7de351b2b9a) | `` ocamlPackages.bigarray-overlap: 0.2.0 → 0.2.1 ``                         |
| [`5f0d203e`](https://github.com/NixOS/nixpkgs/commit/5f0d203e0b6ecc098dc6cdcffc7eeee8ed18647b) | `` ocamlPackages.reason-native.qcheck-rely: fix build (#223793) ``          |
| [`4198fa0f`](https://github.com/NixOS/nixpkgs/commit/4198fa0f02e4b8c04c6f820fa26ee9f941a5077c) | `` python310Packages.gdown: 4.6.4 -> 4.7.1 ``                               |
| [`22b9cbf0`](https://github.com/NixOS/nixpkgs/commit/22b9cbf0b3e3ce6d384643e379effecc500d727a) | `` qq: 3.1.0-9572 -> 3.1.1-11223 ``                                         |
| [`809ba2e2`](https://github.com/NixOS/nixpkgs/commit/809ba2e2a6a6615de70e377973a129ec265cf7b3) | `` vscode-extensions.github.vscode-github-actions: init at 0.25.3 ``        |
| [`0d002e55`](https://github.com/NixOS/nixpkgs/commit/0d002e556270a804bd1e62b7624772aff3b643c2) | `` psol: refactor ``                                                        |
| [`d391265d`](https://github.com/NixOS/nixpkgs/commit/d391265d683ee2459d7d7da1b17c31f240ce5de3) | `` python310Packages.google-cloud-trace: 1.11.0 -> 1.11.1 ``                |
| [`f5d36a2b`](https://github.com/NixOS/nixpkgs/commit/f5d36a2ba4d311efffa9dc648c885218429a0471) | `` automatic-timezoned: 1.0.75 -> 1.0.78 ``                                 |
| [`497e672b`](https://github.com/NixOS/nixpkgs/commit/497e672b267c24d1a7593fcd4a4b0d2468221f3a) | `` musikcube: 0.99.6 -> 0.99.7 ``                                           |
| [`dbeb3f3c`](https://github.com/NixOS/nixpkgs/commit/dbeb3f3c0790b18df355b342b3f79e5c7c8e160c) | `` exploitdb: 2023-03-29 -> 2023-03-30 ``                                   |
| [`0dff2d8a`](https://github.com/NixOS/nixpkgs/commit/0dff2d8a48208d418f08f5ed5f96d502e93af599) | `` containerd: add kubernetes to passthru.tests ``                          |
| [`29b1dacd`](https://github.com/NixOS/nixpkgs/commit/29b1dacd2be29a9013e8d6bcea9525db50f06d3d) | `` containerd: 1.6.19 -> 1.7.0 ``                                           |
| [`52290f39`](https://github.com/NixOS/nixpkgs/commit/52290f39ff7aa9627d5698ae48e188d570a03c3b) | `` terraform-providers.tencentcloud: 1.79.18 → 1.79.19 ``                   |
| [`f5431155`](https://github.com/NixOS/nixpkgs/commit/f5431155e24accf289485e1d4f3dde2f74535017) | `` terraform-providers.okta: 3.44.0 → 3.45.0 ``                             |
| [`28453532`](https://github.com/NixOS/nixpkgs/commit/284535322c858bd2399970425e6387150b28a0c4) | `` terraform-providers.fastly: 4.1.1 → 4.1.2 ``                             |
| [`3d97366d`](https://github.com/NixOS/nixpkgs/commit/3d97366dc9421809cc550ec5a9e161c08d76255a) | `` terraform-providers.cloudfoundry: 0.50.5 → 0.50.6 ``                     |
| [`e64d0861`](https://github.com/NixOS/nixpkgs/commit/e64d0861e610e285e4a2e59203d600a097d59b31) | `` terraform-providers.aiven: 4.1.3 → 4.2.0 ``                              |
| [`458306a7`](https://github.com/NixOS/nixpkgs/commit/458306a751776070fe337ab5f6439f2245389d85) | `` google-cloud-sdk: add libxcrypt-legacy ``                                |
| [`ed520fb7`](https://github.com/NixOS/nixpkgs/commit/ed520fb76a2add7b59d45442752159dfbd4608ea) | `` minio: 2023-03-13T19-46-17Z -> 2023-03-24T21-41-23Z ``                   |
| [`f3dbd5d4`](https://github.com/NixOS/nixpkgs/commit/f3dbd5d4f9d3629ccdd27eaa29a28bc6f1c549b7) | `` cargo-chef: 0.1.51 -> 0.1.52 ``                                          |
| [`1b02bc2e`](https://github.com/NixOS/nixpkgs/commit/1b02bc2ecfb8964cbb64a7abb46ac33fc9a0ae88) | `` grpc_cli: 1.52.1 -> 1.53.0 ``                                            |
| [`5922b34a`](https://github.com/NixOS/nixpkgs/commit/5922b34a40ab81dd29532872ee81ad784687fa57) | `` xmrig: 6.19.0 -> 6.19.1 ``                                               |
| [`36eaee9c`](https://github.com/NixOS/nixpkgs/commit/36eaee9c4686bc252ec7722bfcf1c7b1a2866a9a) | `` minio-client: 2023-02-28T00-12-59Z -> 2023-03-23T20-03-04Z ``            |
| [`81cef56d`](https://github.com/NixOS/nixpkgs/commit/81cef56db49e30363e50929c030444d86a0591d3) | `` cargo-zigbuild: 0.16.4 -> 0.16.5 ``                                      |
| [`bf29f628`](https://github.com/NixOS/nixpkgs/commit/bf29f6288741a372bfcab3d35268029cc7ad488c) | `` twitter-color-emoji: update description to mention "Twemoji" ``          |
| [`7ed83221`](https://github.com/NixOS/nixpkgs/commit/7ed832219968ed77dcbfcb43bf36c044cc76a305) | `` marwaita: 16.2 -> 17 ``                                                  |
| [`befbf587`](https://github.com/NixOS/nixpkgs/commit/befbf58746aba055f42145092179c10236f0db2f) | `` eks-node-viewer: 0.2.0 -> 0.2.1 ``                                       |
| [`f3426464`](https://github.com/NixOS/nixpkgs/commit/f34264640d12c5a9ebe4d170d39241003a73ad02) | `` wishlist: 0.9.0 -> 0.10.0 ``                                             |
| [`ac70a841`](https://github.com/NixOS/nixpkgs/commit/ac70a84187539c0904736907deba8a8aaf7db158) | `` litehtml: don't search for non-existant gumbo cmake config ``            |
| [`77b0cf97`](https://github.com/NixOS/nixpkgs/commit/77b0cf97938453a5bc30370027aca1c5b55f3a77) | `` pritunl-client: 1.3.3474.95 -> 1.3.3477.58 ``                            |
| [`3a0a076e`](https://github.com/NixOS/nixpkgs/commit/3a0a076eb688664269a71cd1e631cf77145088f6) | `` function-runner: 3.2.3 -> 3.2.4 ``                                       |
| [`744c81ef`](https://github.com/NixOS/nixpkgs/commit/744c81ef1c44531101665d14d6a3d0232d95ff21) | `` python310Packages.mlflow: mark insecure ``                               |
| [`d4fecf6c`](https://github.com/NixOS/nixpkgs/commit/d4fecf6c20b1ee29ba30663df448bdb35d110b1e) | `` oh-my-posh: 14.19.3 -> 14.22.0 ``                                        |
| [`9bacd9d6`](https://github.com/NixOS/nixpkgs/commit/9bacd9d621f9f71b5244301a5f8345751fb54810) | `` oh-my-posh: 14.14.3 -> 14.19.3 ``                                        |
| [`c87d1d05`](https://github.com/NixOS/nixpkgs/commit/c87d1d05f84e6432432f31471fcdcfafc5dd2747) | `` probe-run: 0.3.6 -> 0.3.7 ``                                             |
| [`6fc5b40e`](https://github.com/NixOS/nixpkgs/commit/6fc5b40ed4857c78e46e4ea544446f540c419f87) | `` identity: init at 0.5.0 ``                                               |
| [`3690b7e8`](https://github.com/NixOS/nixpkgs/commit/3690b7e88584f4f7d59e4ee6a89dc5c58162c8f3) | `` cargo-vet: 0.5.2 -> 0.6.1 ``                                             |
| [`1dc2dcbf`](https://github.com/NixOS/nixpkgs/commit/1dc2dcbf44a7a2dfc9b0a7b9ffffbf6d52cb87df) | `` cargo-all-features: 1.7.0 -> 1.9.0 ``                                    |
| [`160d82ed`](https://github.com/NixOS/nixpkgs/commit/160d82edc1907a5b64d463726e0e3221c1601eac) | `` erlang_24: 24.3.4.9 -> 24.3.4.10 ``                                      |
| [`c3c78d68`](https://github.com/NixOS/nixpkgs/commit/c3c78d68133c010133f09727e57af78aa9f26c9c) | `` haskellPackages.guardian: mark broken ``                                 |
| [`c7a359b1`](https://github.com/NixOS/nixpkgs/commit/c7a359b13f50c8d026bbcb76f8e115334dc80641) | `` python310Packages.pikepdf: 7.1.1 -> 7.1.2 ``                             |
| [`4e1693c0`](https://github.com/NixOS/nixpkgs/commit/4e1693c09316d9cefda40823ecd5c01f526a6aee) | `` boxxy: 0.6.2 -> 0.6.3 ``                                                 |
| [`9e87f7db`](https://github.com/NixOS/nixpkgs/commit/9e87f7dbde2f1e816f6fb04cfee6b1f316360505) | `` nextcloud-notify_push: 0.6.1 -> 0.6.2 ``                                 |
| [`9e08509f`](https://github.com/NixOS/nixpkgs/commit/9e08509f2b092be808bd7ce7ee24c2cfac8c038c) | `` goresym: 2.1.1 -> 2.2 ``                                                 |
| [`63366ba7`](https://github.com/NixOS/nixpkgs/commit/63366ba77ce0906b26be2ec1f3cb97ff1735d19c) | `` python310Packages.awswrangler: relax openpyxl dependency ``              |
| [`371e5675`](https://github.com/NixOS/nixpkgs/commit/371e567558c65239f36c56b24a261ed0360f5a48) | `` python310Packages.gremlinpython: fix bad version string ``               |
| [`6f037e51`](https://github.com/NixOS/nixpkgs/commit/6f037e51aaa47a3d4d54d4739965fea76bd5405f) | `` pynitrokey: support more devices via libnitrokey ``                      |
| [`e6495b41`](https://github.com/NixOS/nixpkgs/commit/e6495b4112faed54eb87d4a895bf37818bc11e76) | `` python3Packages.spsdk: fix build by relaxing versions ``                 |
| [`428fe359`](https://github.com/NixOS/nixpkgs/commit/428fe359b5a63fb0567011334d255fe09e52ee65) | `` pynitrokey: 0.4.31 -> 0.4.34 ``                                          |
| [`6db14a33`](https://github.com/NixOS/nixpkgs/commit/6db14a3392f2aff688937a8ee7712a2c2aab97a7) | `` raycast: 1.48.9 -> 1.49.0 ``                                             |
| [`281d7c21`](https://github.com/NixOS/nixpkgs/commit/281d7c21c8f64285a9bbd0d4d8d06197fcad23e3) | `` raycast: init at 1.48.9 ``                                               |
| [`847e48c6`](https://github.com/NixOS/nixpkgs/commit/847e48c659f2a1ceed2b7e909983de9d9631ee1c) | `` openxr-loader: 1.0.26 -> 1.0.27 ``                                       |
| [`25c003d6`](https://github.com/NixOS/nixpkgs/commit/25c003d6d52c67c72c74b274c8bc2b64c4e0daa8) | `` python310Packages.yalexs-ble: 2.1.12 -> 2.1.14 ``                        |
| [`73f8689c`](https://github.com/NixOS/nixpkgs/commit/73f8689c601b2b2905c2ec080f68841ef7896bfc) | `` wapiti: 3.1.6 -> 3.1.7 ``                                                |
| [`a1217a2e`](https://github.com/NixOS/nixpkgs/commit/a1217a2ecfecb9de02c2cd5e2b5036408c1a0cfc) | `` qovery-cli: 0.55.0 -> 0.55.2 ``                                          |
| [`1033d0f6`](https://github.com/NixOS/nixpkgs/commit/1033d0f6ac13b7a948090252a2d4386a08deb5b8) | `` (nixos/sanoid, nixos/syncoid): Add package options ``                    |
| [`09d0248a`](https://github.com/NixOS/nixpkgs/commit/09d0248a64536030c254144c49344dff9b5509ff) | `` unciv: 4.5.10 -> 4.5.13 ``                                               |
| [`f6de2d97`](https://github.com/NixOS/nixpkgs/commit/f6de2d9784eee8ea542c11e95865dc6407b51925) | `` chart-testing: 3.7.1 -> 3.8.0 ``                                         |