### PR TITLE
chore(flake/flake-utils): `93a2b84f` -> `11707dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,12 +44,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -196,6 +199,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`11707dc2`](https://github.com/numtide/flake-utils/commit/11707dc2f618dd54ca8739b309ec4fc024de578b) | `` README: add new logo (#120) ``                                            |
| [`fa06cc1b`](https://github.com/numtide/flake-utils/commit/fa06cc1b3d9f8261138ab7e1bc54d115cfcdb6ea) | `` lib: eachDefaultSystemPassThrough/eachSystemPassThrough: init ``          |
| [`58351e44`](https://github.com/numtide/flake-utils/commit/58351e44283ebaf4fa49c4ec1e50754f6ec9ed5e) | `` lib: eachSystem: optimize hot path by assuming rare --impure usage ``     |
| [`db82e07b`](https://github.com/numtide/flake-utils/commit/db82e07bd4c49c5e191d4a913f5875668f30fe63) | `` lib: eachSystem: simplify boolean expression ``                           |
| [`ce5c962a`](https://github.com/numtide/flake-utils/commit/ce5c962a8c847c67cf066f054237d0163eb1649d) | `` lib: eachSystem: inline single-use local variables ``                     |
| [`274ed073`](https://github.com/numtide/flake-utils/commit/274ed073aa7c8923b300cf909befd308ee7aa2d6) | `` lib: eachSystem: improve comments ``                                      |
| [`e8a5a7ba`](https://github.com/numtide/flake-utils/commit/e8a5a7ba2172cc268d144b1c56b419e303add1ab) | `` lib: eachSystem: reformat using 'nixfmt-rfc-style --width 80' ``          |
| [`b1606d7d`](https://github.com/numtide/flake-utils/commit/b1606d7d734203290a39f38a17b9126ca40e6df7) | `` lib: lib: sort inherit statements ``                                      |
| [`988e455b`](https://github.com/numtide/flake-utils/commit/988e455b6f84396a721f8c0b96bbf1264a4da3c0) | `` readme: remove trailing whitespaces ``                                    |
| [`b1d9ab70`](https://github.com/numtide/flake-utils/commit/b1d9ab70662946ef0850d488da1c9019f3a9752a) | `` Bump cachix/install-nix-action from 25 to 26 (#116) ``                    |
| [`d465f481`](https://github.com/numtide/flake-utils/commit/d465f4819400de7c8d874d50b982301f28a84605) | `` Add the current system if --impure is used (#115) ``                      |
| [`1ef2e671`](https://github.com/numtide/flake-utils/commit/1ef2e671c3b0c19053962c07dbda38332dcebf26) | `` Update README.md (#111) ``                                                |
| [`c8eb208c`](https://github.com/numtide/flake-utils/commit/c8eb208c255400b59b60ad5de17e9f8f7ef8ae30) | `` Bump cachix/install-nix-action from 24 to 25 (#113) ``                    |
| [`4022d587`](https://github.com/numtide/flake-utils/commit/4022d587cbbfd70fe950c1e2083a02621806a725) | `` Bump cachix/install-nix-action from 23 to 24 (#109) ``                    |
| [`ff7b65b4`](https://github.com/numtide/flake-utils/commit/ff7b65b44d01cf9ba6a71320833626af21126384) | `` Bump cachix/install-nix-action from 22 to 23 (#106) ``                    |
| [`286e744c`](https://github.com/numtide/flake-utils/commit/286e744c9654ef158fd3b9ef2526966ba41ebf58) | `` Bump actions/checkout from 3 to 4 (#105) ``                               |
| [`1721b3e7`](https://github.com/numtide/flake-utils/commit/1721b3e7c882f75f2301b00d48a2884af8c448ae) | `` README: add light commercial support offer ``                             |
| [`919d646d`](https://github.com/numtide/flake-utils/commit/919d646de7be200f3bf08cb76ae1f09402b6f9b4) | `` Fix typo in ReadMe (#95) ``                                               |
| [`dbabf0ca`](https://github.com/numtide/flake-utils/commit/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7) | `` Add meld (#99) ``                                                         |
| [`abfb11bd`](https://github.com/numtide/flake-utils/commit/abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c) | `` Bump cachix/install-nix-action from 21 to 22 (#100) ``                    |
| [`180473db`](https://github.com/numtide/flake-utils/commit/180473db908bf08c74298bccdf969580237be716) | `` Add test to ensure no special handling of hydraJobs ``                    |
| [`9e0a97e0`](https://github.com/numtide/flake-utils/commit/9e0a97e02654b788ccdfaafe2c719bc0f8411cd6) | `` No special treatment for hydraJobs ``                                     |
| [`a1720a10`](https://github.com/numtide/flake-utils/commit/a1720a10a6cfe8234c0e93907ffe81be440f4cef) | `` Bump cachix/install-nix-action from 20 to 21 (#96) ``                     |
| [`cfacdce0`](https://github.com/numtide/flake-utils/commit/cfacdce06f30d2b68473a46042957675eebb3401) | `` REAMDE: document the systems pattern a bit more ``                        |
| [`033b9f25`](https://github.com/numtide/flake-utils/commit/033b9f258ca96a10e543d4442071f614dc3f8412) | `` clean flake check warnings ``                                             |
| [`2f02e38d`](https://github.com/numtide/flake-utils/commit/2f02e38dfa6cf8afb4d830aad171d8d7cf100c06) | `` update allSystems.nix ``                                                  |
| [`575419ad`](https://github.com/numtide/flake-utils/commit/575419ad23de2f2886a3905163a29b854793338d) | `` split out allSystems.nix ``                                               |
| [`471aed54`](https://github.com/numtide/flake-utils/commit/471aed544aef9c610ea465cddf4a39c358ac5aa8) | `` fixup! introduce externally extensible systems (#93) ``                   |
| [`1c226cc8`](https://github.com/numtide/flake-utils/commit/1c226cc8c6562379ffd0ac36ca095396250d94d7) | `` introduce externally extensible systems (#93) ``                          |
| [`13faa43c`](https://github.com/numtide/flake-utils/commit/13faa43c34c0c943585532dacbb457007416d50b) | `` Use less confusing syntax (#85) ``                                        |
| [`946da791`](https://github.com/numtide/flake-utils/commit/946da791763db1c306b86a8bd3828bf5814a1247) | `` Update documentation for the `systems` argument of `simpleFlake` (#92) `` |
| [`411e8764`](https://github.com/numtide/flake-utils/commit/411e8764155aa9354dbcd6d5faaeb97e9e3dce24) | `` Bump cachix/install-nix-action from 19 to 20 (#89) ``                     |