### PR TITLE
chore(flake/gitignore): `a20de23b` -> `cb5e3fdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                         |
| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`cd6e4278`](https://github.com/hercules-ci/gitignore.nix/commit/cd6e427877711d2dc840447a461cceb19ebfb7cb) | `` Make regression-config-with-store-path work ``               |
| [`ef919372`](https://github.com/hercules-ci/gitignore.nix/commit/ef9193727672eb2776c552195efb5a0a53c35b82) | `` Fix guardNonEmptyString ``                                   |
| [`44b4626e`](https://github.com/hercules-ci/gitignore.nix/commit/44b4626e81d01f2caa3a6a5a4488017622fdb42e) | `` WIP: add regression test for #71 ``                          |
| [`81c6af25`](https://github.com/hercules-ci/gitignore.nix/commit/81c6af2553a6c6b3551941018cc4b35a85de4bbf) | `` fix comment ``                                               |
| [`61ddc300`](https://github.com/hercules-ci/gitignore.nix/commit/61ddc300c1ee8d1f7f48905e4d299fa8d88fcfaf) | `` discard string context of git config's core.excludesFile ``  |
| [`24564f79`](https://github.com/hercules-ci/gitignore.nix/commit/24564f7919d070c32c740934331f0e0f1ae1f399) | `` nix/ci.nix: Test nixos-23.11 ``                              |
| [`71f8c3a2`](https://github.com/hercules-ci/gitignore.nix/commit/71f8c3a2e66302af71352c452b27164cec5d4f5f) | `` ci.nix: Drop nixos-19.03 ``                                  |
| [`dc93a4d2`](https://github.com/hercules-ci/gitignore.nix/commit/dc93a4d2782b4f73b04bb18641d9f29feb8913da) | `` Add outPath short-circuiting tests ``                        |
| [`7a023a99`](https://github.com/hercules-ci/gitignore.nix/commit/7a023a99ca8e37f3114bab4d6298ecc3cef33b9c) | `` Make gitignoreSourceWith short-circuit ``                    |
| [`43e1aa13`](https://github.com/hercules-ci/gitignore.nix/commit/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5) | `` Update README.md ``                                          |
| [`02c007b3`](https://github.com/hercules-ci/gitignore.nix/commit/02c007b372999722e9435208d005fbeeca305f7a) | `` Reminder to port the tests ``                                |
| [`b5594318`](https://github.com/hercules-ci/gitignore.nix/commit/b5594318e5b8118c302b82099b75cdfb25f6ea92) | `` Fix dir with ignored contents bug ``                         |
| [`17ab30e0`](https://github.com/hercules-ci/gitignore.nix/commit/17ab30e0a9fc11aba444ea59fb2ecca41329fe36) | `` flake.lock: Update ``                                        |
| [`1a2cd169`](https://github.com/hercules-ci/gitignore.nix/commit/1a2cd1693215e33aa8186b7b1754ed72342ff174) | `` flake.nix: Wire the checks ``                                |
| [`2eddf711`](https://github.com/hercules-ci/gitignore.nix/commit/2eddf71196502466ef4f8e6c6380c08ca5e1c048) | `` flake.nix: description: does not have to be git ``           |
| [`49e5d6da`](https://github.com/hercules-ci/gitignore.nix/commit/49e5d6daf3a4531fc6736c8b74032e26eae8d145) | `` Format ``                                                    |
| [`3f4a7961`](https://github.com/hercules-ci/gitignore.nix/commit/3f4a79613d027433736a673a9ccffe1985b104b4) | `` Add failing test case for directory with ignored contents `` |