### PR TITLE
chore(flake/flake-compat): `35bb57c0` -> `5edf11c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`aeefe072`](https://github.com/NixOS/flake-compat/commit/aeefe07233c2ebe66a0c449c3804d00e6b91f7eb) | `` doc: reformat with `nixfmt` ``                                      |
| [`075733e9`](https://github.com/NixOS/flake-compat/commit/075733e97e705703432e95e69eb83f0698c94fdc) | `` Improve the README ``                                               |
| [`fd179591`](https://github.com/NixOS/flake-compat/commit/fd1795916b025470ee9d62ae0d891cc89c354355) | `` Drop flakehub-publish action ``                                     |
| [`3070268d`](https://github.com/NixOS/flake-compat/commit/3070268db1f10958e6c1f4477189653455a370cb) | `` add formatter to top level flake ``                                 |
| [`bade378b`](https://github.com/NixOS/flake-compat/commit/bade378b9277aaf845fe79402427b920b311b578) | `` Format with nixfmt ``                                               |
| [`d78897d6`](https://github.com/NixOS/flake-compat/commit/d78897d6254b2cdf54c8a209927cada96f5ec71c) | `` Add tooling ``                                                      |
| [`377e0ab1`](https://github.com/NixOS/flake-compat/commit/377e0ab17de29436f56461449bcde9fadc854877) | `` Revert "Drop "flake = false" and suggest flakehub" ``               |
| [`c16d719e`](https://github.com/NixOS/flake-compat/commit/c16d719e97ac575010dd9b03df6ccf19f87e6a31) | `` Remove `isShallow` check on root source ``                          |
| [`77a761e1`](https://github.com/NixOS/flake-compat/commit/77a761e1abaad48179ec9f0124c593e9defbb0e5) | `` Use correct parent `outPath` for relative path inputs ``            |
| [`17b46650`](https://github.com/NixOS/flake-compat/commit/17b46650be8915f4f526ac0f3bbb03e311568451) | `` fix: Evaluate flake parent source without evaluating its outputs `` |
| [`98fed477`](https://github.com/NixOS/flake-compat/commit/98fed477b0a501881c4f4cd798ba89eaef53b211) | `` call-flake.nix: allNodes.${key} -> allNodes.${key}.result ``        |
| [`a7bab49e`](https://github.com/NixOS/flake-compat/commit/a7bab49e4f8a7323e1e289ae7a7e0fe73a8d3c5d) | `` call-flake.nix: refactor: Bring mapAttrs into scope ``              |
| [`1b568a04`](https://github.com/NixOS/flake-compat/commit/1b568a049aa5f4bf98351228c6a2fba9ab4f7f2c) | `` Add support for relative path inputs ``                             |
| [`17b9a975`](https://github.com/NixOS/flake-compat/commit/17b9a975f3114498d7445eb6b86d8fa69d48747b) | `` Format with nixfmt ``                                               |
| [`a220b6b7`](https://github.com/NixOS/flake-compat/commit/a220b6b7b9c8dcf86fd99e13a7f5f8a28e7c386f) | `` Fix non-fetchTree pure-eval use of builtins.path ``                 |
| [`a1b45cd4`](https://github.com/NixOS/flake-compat/commit/a1b45cd4a224023888702a60d6830bc0ab40c038) | `` Return all outputs ``                                               |
| [`3980b5e4`](https://github.com/NixOS/flake-compat/commit/3980b5e441bac46246f9f11c77085ed5a2c73912) | `` Expose revCount attribute for git inputs ``                         |
| [`520e73f6`](https://github.com/NixOS/flake-compat/commit/520e73f623ca5e1f61ee4b5f07a9a700e67c0e95) | `` Use builtins.fetchTree if available ``                              |
| [`baa7aa7b`](https://github.com/NixOS/flake-compat/commit/baa7aa7bd0a570b3b9edd0b8da859fee3ffaa4d4) | `` Check for pure eval mode before calling `builtins.storePath` ``     |
| [`b7cd5940`](https://github.com/NixOS/flake-compat/commit/b7cd594063b9118c198bbdb4c22c19ca0919822a) | `` README: fix node name look-up ``                                    |
| [`0f9255e0`](https://github.com/NixOS/flake-compat/commit/0f9255e01c2351cc7d116c072cb317785dd33b33) | `` Force root sources like "./." into the Nix store ``                 |
| [`5a16547d`](https://github.com/NixOS/flake-compat/commit/5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad) | `` Prevent double copying and work around an apparent Nix bug ``       |
| [`4f910c98`](https://github.com/NixOS/flake-compat/commit/4f910c9827911b1ec2bf26b5a062cd09f8d89f85) | `` Doh ``                                                              |
| [`7ae5ae62`](https://github.com/NixOS/flake-compat/commit/7ae5ae625a69a4c160e7f5e975e8d5c06a7aee92) | `` Drop "flake = false" and suggest flakehub ``                        |
| [`bc5e257a`](https://github.com/NixOS/flake-compat/commit/bc5e257a8d0c4df04652ecff9053d05b0dc9484e) | `` nix#7796: Ensure that `self.outPath == ./.` ``                      |
| [`2bf43d60`](https://github.com/NixOS/flake-compat/commit/2bf43d60c7596e26d6f56dde17a466b158a6abb4) | `` Change from rolling to tagged releases ``                           |
| [`6256b599`](https://github.com/NixOS/flake-compat/commit/6256b599c81a9ae3f9fc18f88ad4ab3d7cf2534f) | `` Add description ``                                                  |
| [`c30381e1`](https://github.com/NixOS/flake-compat/commit/c30381e188d2edb0a7bc866aa59d7ac1831f4b59) | `` Add flake.nix ``                                                    |
| [`92556b85`](https://github.com/NixOS/flake-compat/commit/92556b853911f0ef60fd88d2e0fa4d67afbc8dba) | `` Add FlakeHub publish Action ``                                      |
| [`bcb80df0`](https://github.com/NixOS/flake-compat/commit/bcb80df05106afa74c7149f74f3b8fabce052bac) | `` add support for sourcehut ``                                        |